### PR TITLE
Adding 'new_record' field for all schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 
 CHANGELOG
 AUTHORS
+
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - '3.5'
 
 before_install:
-  - travis_retry pip install --upgrade pip setuptools py
+  - travis_retry pip install --upgrade pip setuptools py coveralls
   - travis_retry pip install -r requirements-test.txt
   - pip freeze
 

--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -147,6 +147,11 @@
             "description": "Stores name in native form.",
             "type": "array"
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "other_names": {
             "description": "Contains other variation of names. Usually a different form of writing the primary name.",
             "items": {

--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -62,6 +62,11 @@
             "type": "array",
             "uniqueItems": true
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "nonpublic_note": {
             "title": "Non public note",
             "type": "string"

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -109,6 +109,11 @@
             "title": "Hidden note",
             "type": "string"
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "nonpublic_note": {
             "description": "FIXME: difference from hidden_note!?",
             "title": "Non public note",

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -129,6 +129,11 @@
             "type": "array",
             "uniqueItems": true
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "non_public_notes": {
             "items": {
                 "title": "Non-Public note",

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -81,6 +81,11 @@
             "type": "array",
             "uniqueItems": true
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "position": {
             "title": "Job position",
             "type": "string"

--- a/inspire_schemas/records/journals.json
+++ b/inspire_schemas/records/journals.json
@@ -74,6 +74,11 @@
             "type": "array",
             "uniqueItems": true
         },
+        "new_record": {
+            "$ref": "elements/json_reference.json",
+            "description": "Master record that replaces this record",
+            "title": "New record"
+        },
         "nonpublic_note": {
             "title": "Non public note",
             "type": "string"

--- a/scripts/generate_example_records.js
+++ b/scripts/generate_example_records.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 //requires the json-schema-faker npm package installed
-var jsf = require('json-schema-faker')
+var fs = require('fs',
+    jsf = require('json-schema-faker'),
+    path = require('path');
 
 jsf.format('ISO 639-1', function(gen, schema){ return gen.randexp('^1.*$');});
 jsf.format('date', function(gen, schema){ return gen.randexp('^1.*$');});

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -115,6 +115,9 @@
         "value": ")qk,t/ [((>?! oOEE=a8uIb\"u5V_J@/%qmn&YH,:1:stA@z}TNi/lrF{*X;YBt-e=J*AFmNsTF_(4[dtSFMpIWt1*:pA, UZ~oG)`hd5AYA.FW@M-Wq3+ag7a\\:J~4(3aIM7mbYg;5yOSyv,S?Az`ncWRH{cBAv`L%jEsmY"
     },
     "native_name": [],
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "other_names": [
         "ad non",
         "sed cupidatat Duis ut",

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -109,6 +109,9 @@
             "value": "sunt ut nulla"
         }
     ],
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "nonpublic_note": "voluptate culpa ipsum anim incididunt",
     "note": [],
     "opening_date": "1V_5^kBacxK2f+DgAPp*}jGfAQ1e+7dkR+n+cZk[JP#f&GO$[6,0Y\"C]h [R)dc31",

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -73,6 +73,9 @@
         "cillum culpa ut ut nulla"
     ],
     "hidden_note": "dolor ut cillum",
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "nonpublic_note": "dolor labore voluptate",
     "other_experiment_names": [
         {

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -102,6 +102,9 @@
             ]
         }
     ],
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "non_public_notes": [
         "aliquip"
     ],

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -100,6 +100,9 @@
             }
         }
     ],
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "position": "incididunt est amet cillum dolor",
     "ranks": [
         "UNDERGRADUATE",

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -59,6 +59,9 @@
             "value": "1kaeYi96?cHS(He9DVeVEr47|U9\\rS+JkqP^S6X*cEO/cf<8k$/TRV*"
         }
     ],
+    "new_record": {
+        "$ref": "1M\"?!ouZ]W}^ 6ZBtT (OpV2~FoO1*YXan`6q+Zz{|E}b&Rty<P]6o0i)l[,YDwm4_9c}HnG.:l_H"
+    },
     "nonpublic_note": "sint",
     "peer_reviewed": false,
     "public_note": "magna Ut et",


### PR DESCRIPTION
* NEW addresses [inspirehep/inspire-next#1609](https://github.com/inspirehep/inspire-next/issues/1609).

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>