### PR TITLE
scripts: fix generate_example_records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 
 CHANGELOG
 AUTHORS
+
+node_modules

--- a/scripts/generate_example_records.js
+++ b/scripts/generate_example_records.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 //requires the json-schema-faker npm package installed
-var jsf = require('json-schema-faker')
+var fs = require('fs',
+    jsf = require('json-schema-faker'),
+    path = require('path');
 
 jsf.format('ISO 639-1', function(gen, schema){ return gen.randexp('^1.*$');});
 jsf.format('date', function(gen, schema){ return gen.randexp('^1.*$');});


### PR DESCRIPTION
* Makes `scripts/generate_example_records.json` work out of the box
  by adding the proper requires and making it executable.

* Also adds `node_modules` to `.gitignore` so that we can `npm install
  json-schema-faker` locally.

Signed-off-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>