### PR TITLE
authors: use the same values as rank enum

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -12,10 +12,10 @@
                     },
                     "degree_type": {
                         "enum": [
-                            "PhD",
-                            "Master",
-                            "Bachelor",
-                            "Other"
+                            "PHD",
+                            "MASTER",
+                            "BACHELOR",
+                            "OTHER"
                         ],
                         "type": "string"
                     },


### PR DESCRIPTION
- This way we have a more consistent set of possible values.

Signed-off-by: David Caro david@dcaro.es
