### PR TITLE
authors: reintroduce old_emails

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -200,6 +200,13 @@
                         },
                         "type": "object"
                     },
+                    "old_emails": {
+                        "items": {
+                            "format": "email",
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "rank": {
                         "$ref": "elements/rank.json"
                     },


### PR DESCRIPTION
* Since we still need to import/export from legacy, reintroduce
  explicit old_emails and emails in positions to avoid losing information.