### PR TITLE
hep: Insertion of fields `$schema` and `control_number` in hep.json.

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -2,6 +2,10 @@
     "$schema": "http://json-schema.org/schema#",
     "description": "An article or thesis or book or...",
     "properties": {
+        "$schema": {
+            "format": "url",
+            "type": "string"
+        },
         "abstracts": {
             "items": {
                 "properties": {
@@ -253,6 +257,9 @@
             "title": "Collection",
             "type": "array",
             "uniqueItems": true
+        },
+        "control_number": {
+            "type": "integer"
         },
         "copyright": {
             "items": {


### PR DESCRIPTION
* Insertion of the `$schema` and `control_number` fields in the hep schema
   as it is required for using invenio-records-rest PUT request upon updating
   a single record.

Signed-off-by: Zacharias Zacharodimos <zacharias.zacharodimos@cern.ch>