### PR TITLE
hep: add $schema and control_number

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -2,6 +2,10 @@
     "$schema": "http://json-schema.org/schema#",
     "description": "An article or thesis or book or...",
     "properties": {
+        "$schema": {
+            "format": "url",
+            "type": "string"
+        },
         "abstracts": {
             "items": {
                 "properties": {
@@ -253,6 +257,9 @@
             "title": "Collection",
             "type": "array",
             "uniqueItems": true
+        },
+        "control_number": {
+            "type": "integer"
         },
         "copyright": {
             "items": {


### PR DESCRIPTION
INCOMPATIBLE Adds the `$schema` and `control_number` fields to the hep
schema because they are required by `invenio-records-rest` to support PUT
requests.