### PR TITLE
Remove oneOf from schemas

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -103,11 +103,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -44,11 +44,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspire_schemas/records/elements/inspire_field.json
+++ b/inspire_schemas/records/elements/inspire_field.json
@@ -1,33 +1,36 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "source": {
-        "enum": [
-            "curator",
-            "magpie",
-            "arxiv",
-            "user",
-            "undefined"
-        ],
-        "type": "string"
+    "properties": {
+        "source": {
+            "enum": [
+                "curator",
+                "magpie",
+                "arxiv",
+                "user",
+                "undefined"
+            ],
+            "type": "string"
+        },
+        "term": {
+            "enum": [
+                "Accelerators",
+                "Astrophysics",
+                "Computing",
+                "Data Analysis and Statistics",
+                "Experiment-HEP",
+                "Experiment-Nucl",
+                "General Physics",
+                "Gravitation and Cosmology",
+                "Instrumentation",
+                "Lattice",
+                "Math and Math Physics",
+                "Other",
+                "Phenomenology-HEP",
+                "Theory-HEP",
+                "Theory-Nucl"
+            ],
+            "type": "string"
+        }
     },
-    "term": {
-        "enum": [
-            "Accelerators",
-            "Astrophysics",
-            "Computing",
-            "Data Analysis and Statistics",
-            "Experiment-HEP",
-            "Experiment-Nucl",
-            "General Physics",
-            "Gravitation and Cosmology",
-            "Instrumentation",
-            "Lattice",
-            "Math and Math Physics",
-            "Other",
-            "Phenomenology-HEP",
-            "Theory-HEP",
-            "Theory-Nucl"
-        ],
-        "type": "string"
-    }
+    "type": "object"
 }

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -107,11 +107,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -458,11 +458,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -102,11 +102,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -55,11 +55,7 @@
         },
         "inspire_categories": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "elements/inspire_field.json"
-                    }
-                ]
+                "$ref": "elements/inspire_field.json"
             },
             "type": "array",
             "uniqueItems": true


### PR DESCRIPTION
* Removes unnecessary oneOf from schemas.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>