### PR TITLE
hep: number_of_pages instead of page_nr

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -548,13 +548,9 @@
             "description": "Master record that replaces this record",
             "title": "New record"
         },
-        "page_nr": {
-            "items": {
-                "description": "FIXME: shall it be integer perhaps?",
-                "title": "Number of pages",
-                "type": "string"
-            },
-            "type": "array"
+        "number_of_pages": {
+            "minimum": 1,
+            "type": "integer"
         },
         "persistent_identifiers": {
             "items": {


### PR DESCRIPTION
* INCOMPATIBLE removes page_nr which was confusing everyone

* NEW adds number_of_pages for the number of pages in the document

* Closes #63

Signed-off-by: Micha Moskovic <michamos@gmail.com>