### PR TITLE
hep: merge classification_number into keywords

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -230,30 +230,6 @@
             "title": "Citeable?",
             "type": "boolean"
         },
-        "classification_number": {
-            "items": {
-                "properties": {
-                    "source": {
-                        "title": "Source",
-                        "type": "string"
-                    },
-                    "standard": {
-                        "title": "Standard",
-                        "type": "string"
-                    },
-                    "value": {
-                        "description": "PACS or PDG codes. FIXME: What about better separating these into a PACS field and a PDG field?",
-                        "title": "Number",
-                        "type": "string"
-                    }
-                },
-                "title": "Classification number",
-                "type": "object"
-            },
-            "title": "Classification numbers",
-            "type": "array",
-            "uniqueItems": true
-        },
         "collaborations": {
             "items": {
                 "properties": {
@@ -515,13 +491,19 @@
         "keywords": {
             "items": {
                 "properties": {
-                    "classification_scheme": {
-                        "type": "string"
-                    },
-                    "keyword": {
+                    "schema": {
+                        "description": "The particular vocabulary against which this keyword is valid and found. Leave empty for free form keywords",
+                        "enum": [
+                            "INSPIRE",
+                            "PACS",
+                            "PDG"
+                        ],
                         "type": "string"
                     },
                     "source": {
+                        "type": "string"
+                    },
+                    "value": {
                         "type": "string"
                     }
                 },

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -177,18 +177,6 @@
         }
     ],
     "citeable": true,
-    "classification_number": [
-        {
-            "source": "incididunt sunt labo",
-            "standard": "veniam dolore esse",
-            "value": "amet anim eu"
-        },
-        {
-            "source": "sunt do officia dolore nulla",
-            "standard": "labore laboris sit",
-            "value": "nisi do in non Ut"
-        }
-    ],
     "collaboration": [
         {
             "record": {
@@ -399,14 +387,14 @@
     ],
     "keywords": [
         {
-            "classification_scheme": "nulla eiusmod tempor in",
-            "keyword": "ipsum aliquip commodo nisi ex",
-            "source": "cupidatat Lorem et commodo"
+            "schema": "PACS",
+            "source": "cupidatat Lorem et commodo",
+            "value": "ipsum aliquip commodo nisi ex"
         },
         {
-            "classification_scheme": "do proident",
-            "keyword": "minim in ad magna",
-            "source": "ullamco mollit anim laboris"
+            "schema": "PDG",
+            "source": "ullamco mollit anim laboris",
+            "value": "minim in ad magna"
         }
     ],
     "languages": [


### PR DESCRIPTION
* INCOMPATIBLE Merges classification_number into keywords field.
  (closes #52)

* INCOMPATIBLE Renames keywords.keyword->keywords.value,
  keywords.classification_scheme->keywords.schema

* NEW Introduces an enum for keywords.schema.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>