### PR TITLE
hep: thesis_supervisor superseded by inspire_roles

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -822,38 +822,6 @@
             },
             "type": "object"
         },
-        "thesis_supervisors": {
-            "items": {
-                "properties": {
-                    "affiliations": {
-                        "items": {
-                            "properties": {
-                                "curated_relation": {
-                                    "type": "boolean"
-                                },
-                                "record": {
-                                    "$ref": "elements/json_reference.json"
-                                },
-                                "value": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "full_name": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "full_name"
-                ],
-                "type": "object"
-            },
-            "type": "array",
-            "uniqueItems": true
-        },
         "title_translations": {
             "items": {
                 "properties": {


### PR DESCRIPTION
* INCOMPATIBLE removes "thesis_supervisor", which is superseded by the
  "supervisor" value in "inspire_roles"