### PR TITLE
schemas: add noAdditionalProperties everywhere

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "_private_note": {
             "type": "string"
@@ -9,6 +10,7 @@
         },
         "advisors": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "_degree_type": {
                         "type": "string"
@@ -42,6 +44,7 @@
         },
         "collections": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "primary": {
                         "type": "string"
@@ -81,6 +84,7 @@
         "experiments": {
             "description": "Contains information about experiments.",
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "type": "boolean"
@@ -123,6 +127,7 @@
         },
         "name": {
             "description": "Contains name information.",
+            "noAdditionalProperties": true,
             "properties": {
                 "numeration": {
                     "enum": [
@@ -187,6 +192,7 @@
         },
         "positions": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "_rank": {
                         "type": "string"
@@ -206,6 +212,7 @@
                         "type": "string"
                     },
                     "institution": {
+                        "noAdditionalProperties": true,
                         "properties": {
                             "curated_relation": {
                                 "type": "boolean"
@@ -264,11 +271,12 @@
         "source": {
             "description": "This is the source of informatio. It is currently a mixed bags of user IDs or provenance information, e.g. arXiv etc. FIXME: we should really discuss about it. E.g. eprint, webform, Rachel.Lumpkin@durham.ac.uk(96), Fermilab, C09-05-04, KYOTOU...",
             "items": {
-                "date_verified": {
-                    "format": "date",
-                    "type": "string"
-                },
+                "noAdditionalProperties": true,
                 "properties": {
+                    "date_verified": {
+                        "format": "date",
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     }

--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "acronym": {
             "items": {
@@ -49,6 +50,7 @@
         },
         "keywords": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "type": "string"
@@ -96,6 +98,7 @@
         },
         "series": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "name": {
                         "type": "string"
@@ -115,6 +118,7 @@
         },
         "short_description": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "type": "string"

--- a/inspire_schemas/records/elements/acquisition_source.json
+++ b/inspire_schemas/records/elements/acquisition_source.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "date": {
             "type": "string"

--- a/inspire_schemas/records/elements/address.json
+++ b/inspire_schemas/records/elements/address.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "description": "Address",
+    "noAdditionalProperties": true,
     "properties": {
         "city": {
             "description": "City",

--- a/inspire_schemas/records/elements/contact.json
+++ b/inspire_schemas/records/elements/contact.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "description": "Contact person's data",
+    "noAdditionalProperties": true,
     "properties": {
         "email": {
             "description": "Contact person's e-mail",

--- a/inspire_schemas/records/elements/id.json
+++ b/inspire_schemas/records/elements/id.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/schema#",
     "anyOf": [
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -17,6 +18,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -32,6 +34,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -47,6 +50,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -62,6 +66,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -77,6 +82,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -92,6 +98,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -107,6 +114,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -122,6 +130,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -137,6 +146,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -152,6 +162,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -167,6 +178,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -182,6 +194,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [
@@ -197,6 +210,7 @@
             "type": "object"
         },
         {
+            "noAdditionalProperties": true,
             "properties": {
                 "type": {
                     "enum": [

--- a/inspire_schemas/records/elements/inspire_field.json
+++ b/inspire_schemas/records/elements/inspire_field.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "source": {
             "enum": [

--- a/inspire_schemas/records/elements/json_reference.json
+++ b/inspire_schemas/records/elements/json_reference.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "$ref": {
             "description": "URL to the referenced resource",

--- a/inspire_schemas/records/elements/reference.json
+++ b/inspire_schemas/records/elements/reference.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "description": "record-like Schema for a Publication's reference",
+    "noAdditionalProperties": true,
     "properties": {
         "arxiv_eprints": {
             "items": {
@@ -13,6 +14,7 @@
         "authors": {
             "description": "List with all the authors",
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "full_name": {
                         "type": "string"
@@ -28,6 +30,7 @@
             "uniqueItems": true
         },
         "book_series": {
+            "noAdditionalProperties": true,
             "properties": {
                 "title": {
                     "description": "Title of the book series",
@@ -56,6 +59,7 @@
             "uniqueItems": true
         },
         "imprint": {
+            "noAdditionalProperties": true,
             "properties": {
                 "date": {
                     "format": "date",
@@ -89,6 +93,7 @@
             "uniqueItems": true
         },
         "publication_info": {
+            "noAdditionalProperties": true,
             "properties": {
                 "artid": {
                     "description": "Electronic Article ID",

--- a/inspire_schemas/records/elements/title.json
+++ b/inspire_schemas/records/elements/title.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "source": {
             "type": "string"

--- a/inspire_schemas/records/elements/url.json
+++ b/inspire_schemas/records/elements/url.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "description": {
             "type": "string"

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "accelerator": {
             "title": "Accelerator",
@@ -7,6 +8,7 @@
         },
         "affiliations": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "type": "boolean"
@@ -135,6 +137,7 @@
         },
         "related_experiments": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "title": "Is the relation curated?",
@@ -171,6 +174,7 @@
         },
         "spokespersons": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "title": "Is the relation curated?",

--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "description": "An article or thesis or book or...",
+    "noAdditionalProperties": true,
     "properties": {
         "$schema": {
             "format": "url",
@@ -8,6 +9,7 @@
         },
         "abstracts": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "$ref": "elements/source.json"
@@ -23,6 +25,7 @@
         },
         "accelerator_experiments": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "accelerator": {
                         "type": "string"
@@ -54,6 +57,7 @@
         "arxiv_eprints": {
             "description": "Read only meta-data (identifiers and categories) coming from arXiv",
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "categories": {
                         "items": {
@@ -78,9 +82,11 @@
         "authors": {
             "description": "Anybody who has acted on a given document (including supervisors, editors, etc.)",
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "affiliations": {
                         "items": {
+                            "noAdditionalProperties": true,
                             "properties": {
                                 "curated_relation": {
                                     "description": "Does this affiliation point to the correct Institution?",
@@ -171,6 +177,7 @@
                     },
                     "raw_affiliations": {
                         "items": {
+                            "noAdditionalProperties": true,
                             "properties": {
                                 "source": {
                                     "$ref": "elements/source.json"
@@ -211,6 +218,7 @@
         },
         "book_series": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "title": {
                         "description": "Title of the book series",
@@ -232,6 +240,7 @@
         },
         "collaborations": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "record": {
                         "$ref": "elements/json_reference.json"
@@ -247,6 +256,7 @@
         },
         "collections": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "primary": {
                         "type": "string"
@@ -264,6 +274,7 @@
         },
         "copyright": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "holder": {
                         "description": "Copyright holder.",
@@ -329,6 +340,7 @@
         },
         "dois": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "material": {
                         "$ref": "elements/material.json"
@@ -351,6 +363,7 @@
         },
         "edition": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "edition": {
                         "type": "string"
@@ -371,6 +384,7 @@
         },
         "external_system_identifiers": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "schema": {
                         "type": "string"
@@ -387,6 +401,7 @@
         "funding_info": {
             "description": "Information related to funding. FIXME: Do we care about this? So far only 349 records were tagged and all for a single EU project.",
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "agency": {
                         "title": "Agency",
@@ -410,6 +425,7 @@
         },
         "hidden_notes": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "$ref": "elements/source.json"
@@ -425,6 +441,7 @@
         },
         "imprints": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "date": {
                         "format": "date",
@@ -451,6 +468,7 @@
         },
         "isbns": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "comment": {
                         "description": "Further information about type.",
@@ -474,6 +492,7 @@
         },
         "keywords": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "schema": {
                         "description": "The particular vocabulary against which this keyword is valid and found. Leave empty for free form keywords",
@@ -506,6 +525,7 @@
         },
         "license": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "imposing": {
                         "description": "FIXME: what is this!?",
@@ -543,6 +563,7 @@
         },
         "persistent_identifiers": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "schema": {
                         "title": "Type of persistent identifier (e.g. HDL, URN)",
@@ -569,6 +590,7 @@
         },
         "public_notes": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "$ref": "elements/source.json"
@@ -587,6 +609,7 @@
         },
         "publication_info": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "artid": {
                         "description": "Electronic Article ID",
@@ -670,12 +693,14 @@
         },
         "references": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "type": "boolean"
                     },
                     "raw_refs": {
                         "items": {
+                            "noAdditionalProperties": true,
                             "properties": {
                                 "position": {
                                     "description": "The position of the reference as it appears on the document",
@@ -714,6 +739,7 @@
         },
         "report_numbers": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "$ref": "elements/source.json"
@@ -757,6 +783,7 @@
         },
         "succeeding_entry": {
             "description": "Reference to previously merged records.",
+            "noAdditionalProperties": true,
             "properties": {
                 "isbn": {
                     "pattern": "^(97(8|9))?\\d{9}(\\d|X)$",
@@ -779,6 +806,7 @@
             "uniqueItems": true
         },
         "thesis_info": {
+            "noAdditionalProperties": true,
             "properties": {
                 "date": {
                     "format": "date",
@@ -793,6 +821,7 @@
                 },
                 "institutions": {
                     "items": {
+                        "noAdditionalProperties": true,
                         "properties": {
                             "curated_relation": {
                                 "type": "boolean"
@@ -814,6 +843,7 @@
         },
         "title_translations": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "language": {
                         "pattern": "^\\w{2}$",

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "ICN": {
             "description": "HEP affiliation following new standards",
@@ -77,6 +78,7 @@
             "items": {
                 "anyOf": [
                     {
+                        "noAdditionalProperties": true,
                         "properties": {
                             "type": {
                                 "enum": [
@@ -121,6 +123,7 @@
             "type": "string"
         },
         "location": {
+            "noAdditionalProperties": true,
             "properties": {
                 "latitude": {
                     "description": "FIXME: we can populate this programmatically with Google APIs",
@@ -138,6 +141,7 @@
         },
         "name_variants": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "source": {
                         "description": "FIXME: Do we really care about the source?",
@@ -190,6 +194,7 @@
         },
         "related_institutes": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "title": "Is the relation curated?",

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "address": {
             "items": {
@@ -34,6 +35,7 @@
         },
         "experiments": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "type": "boolean"
@@ -62,6 +64,7 @@
         },
         "institutions": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "curated_relation": {
                         "type": "boolean"

--- a/inspire_schemas/records/journals.json
+++ b/inspire_schemas/records/journals.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "noAdditionalProperties": true,
     "properties": {
         "coden": {
             "items": {
@@ -20,6 +21,7 @@
         },
         "issn": {
             "items": {
+                "noAdditionalProperties": true,
                 "properties": {
                     "comment": {
                         "description": "Further information about type.",
@@ -99,6 +101,7 @@
             "type": "array"
         },
         "relation": {
+            "noAdditionalProperties": true,
             "properties": {
                 "curated_relation": {
                     "title": "Is the relation curated?",


### PR DESCRIPTION
* BETTER Adds noAdditionalProperties everywhere.
  (closes #26)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>