### PR TITLE
hep: improved enums

### DIFF
--- a/inspire_schemas/records/elements/acquisition_source.json
+++ b/inspire_schemas/records/elements/acquisition_source.json
@@ -9,6 +9,12 @@
             "type": "string"
         },
         "method": {
+            "enum": [
+                "submitter",
+                "oai",
+                "batchuploader",
+                "hepcrawl"
+            ],
             "type": "string"
         },
         "orcid": {

--- a/inspire_schemas/records/elements/medium.json
+++ b/inspire_schemas/records/elements/medium.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "enum": [
+        "print",
+        "online",
+        "paperback",
+        "hardcover"
+    ],
+    "type": "string"
+}

--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -474,8 +474,8 @@
                         "description": "Further information about type.",
                         "type": "string"
                     },
-                    "material": {
-                        "$ref": "elements/material.json"
+                    "medium": {
+                        "$ref": "elements/medium.json"
                     },
                     "value": {
                         "pattern": "^(97(8|9))?\\d{9}(\\d|X)$",


### PR DESCRIPTION
* INCOMPATIBLE Replaces isbns.material with isbns.medium.

* NEW Introduces an enum for acquisition_source methods.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>