### PR TITLE
schemas: kill collections

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -42,20 +42,6 @@
             "format": "date",
             "type": "string"
         },
-        "collections": {
-            "items": {
-                "additionalProperties": false,
-                "properties": {
-                    "primary": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "minItems": 1,
-            "type": "array",
-            "uniqueItems": true
-        },
         "conferences": {
             "description": "Contains information about attended conferences. (their record URIs)",
             "items": {
@@ -302,6 +288,9 @@
                 "retired"
             ],
             "type": "string"
+        },
+        "stub": {
+            "type": "boolean"
         },
         "urls": {
             "items": {

--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -240,21 +240,6 @@
             "type": "array",
             "uniqueItems": true
         },
-        "collections": {
-            "items": {
-                "additionalProperties": false,
-                "properties": {
-                    "primary": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "minItems": 1,
-            "title": "Collection",
-            "type": "array",
-            "uniqueItems": true
-        },
         "control_number": {
             "type": "integer"
         },
@@ -713,7 +698,7 @@
             "description": "Url of the record itself",
             "title": "Url of the record"
         },
-        "special_collection": {
+        "special_collections": {
             "items": {
                 "enum": [
                     "CDF-INTERNAL-NOTE",

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -1,309 +1,287 @@
 {
     "_private_notes": [
         {
-            "source": "Lorem nisi",
-            "value": "exercitation consequat in"
+            "source": "minim fugiat in eu",
+            "value": "Duis occaecat cupidatat elit"
         },
         {
-            "source": "aliqua proident",
-            "value": "officia in"
+            "source": "sed minim aliqua",
+            "value": "est consectet"
         },
         {
-            "source": "ipsum incididunt",
-            "value": "ut mollit velit"
+            "source": "Duis Excepteur",
+            "value": "sed"
+        },
+        {
+            "source": "Duis ullamco",
+            "value": "laboris i"
+        },
+        {
+            "source": "dolor Ut consequat",
+            "value": "amet qui eu"
         }
     ],
     "acquisition_source": {
-        "date": "Excepteur proident exercitation cupidatat",
-        "email": "ess",
-        "method": "in exercitation ut id",
-        "orcid": "4230-9303-8129-0280",
-        "source": "proident dolore Lorem ",
-        "submission_number": "minim"
+        "date": "ut Duis in consequat",
+        "email": "esse qui cupidatat officia amet",
+        "method": "quis in",
+        "orcid": "3993-4083-2278-5305",
+        "source": "eu tempor",
+        "submission_number": "dolor"
     },
     "advisors": [
         {
-            "_degree_type": "sunt esse in",
+            "_degree_type": "a",
             "curated_relation": false,
-            "degree_type": "laurea",
-            "name": "in",
+            "degree_type": "habilitation",
+            "name": "esse",
             "record": {
-                "$ref": "http://1\"d/"
-            }
-        },
-        {
-            "_degree_type": "eu veniam qui",
-            "curated_relation": true,
-            "degree_type": "master",
-            "name": "dolor",
-            "record": {
-                "$ref": "http://10)m-"
-            }
-        },
-        {
-            "_degree_type": "incididunt",
-            "curated_relation": false,
-            "degree_type": "other",
-            "name": "commodo",
-            "record": {
-                "$ref": "http://1oMk"
-            }
-        },
-        {
-            "_degree_type": "occaecat",
-            "curated_relation": false,
-            "degree_type": "bachelor",
-            "name": "labore sunt",
-            "record": {
-                "$ref": "http://1};NFAE"
+                "$ref": "http://1oA4cd"
             }
         }
     ],
     "birth_date": "dddd-dd-dd",
-    "collections": [
-        {
-            "primary": "id irure labo"
-        },
-        {
-            "primary": "tempor ut"
-        },
-        {
-            "primary": "ut tempor"
-        },
-        {
-            "primary": "amet enim"
-        }
-    ],
     "conferences": [
         {
             "$ref": "http://1"
         }
     ],
     "death_date": "dddd-dd-dd",
-    "deleted": false,
+    "deleted": true,
     "email_addresses": [
-        "N2nxAYSpZsd3R@xbVYzpXzxHTHApZHRPoIqrAmo.opj",
-        "0oMtarbw@HHQmyKQpsexflFRH.rmkk",
-        "1fKX0Cd7U@agUnUMclM.usv"
+        "xmiUzG@gLYnAgRHCIfpmvJrlsiIeCcBijzPEt.fnv",
+        "fKhgjLjbN@cZdSyjsXmcifcUfZayF.iw",
+        "q3YwNEi2ClmVrL@fUpFvrVAnMnAVuSCxjJRZ.nqr",
+        "XlO8LYguXjEs@r.pmt",
+        "pA7Ba725hX5j@EzwJaFEPrpmDkRlzyjWpzFPjvAcgZoOo.bbab"
     ],
     "experiments": [
         {
             "curated_relation": true,
             "current": true,
-            "end_year": 35035074,
-            "name": "Duis",
+            "end_year": 34228885,
+            "name": "ut mollit id",
             "record": {
-                "$ref": "http://1?pPF`"
+                "$ref": "http://1Reg-/"
             },
-            "start_year": -41334728
+            "start_year": 61934614
+        },
+        {
+            "curated_relation": false,
+            "current": false,
+            "end_year": 17562937,
+            "name": "deserunt commodo cillum sit sint",
+            "record": {
+                "$ref": "http://1G6btmz7*sa"
+            },
+            "start_year": 95493676
         }
     ],
     "ids": [
         {
-            "anim4ea": 10805121,
-            "exercitation238": "nulla Lorem ex culpa",
-            "type": "ORCID",
-            "value": "2002-1318-5379-3888"
+            "exercitation0": "velit Excepteur cillum mollit",
+            "ind4b": -25269929,
+            "type": "INSPIRE ID",
+            "value": "INSPIRE-18160543"
+        },
+        {
+            "cupidatatb": true,
+            "occaecatff6": true,
+            "type": "INSPIRE ID",
+            "value": "INSPIRE-10013328"
+        },
+        {
+            "Excepteur089": -47809409,
+            "aliqua0": false,
+            "type": "INSPIRE ID",
+            "value": "INSPIRE-71586719"
         }
     ],
     "inspire_categories": [
         {
-            "source": "user",
-            "term": "Gravitation and Cosmology"
-        },
-        {
-            "source": "arxiv",
-            "term": "Phenomenology-HEP"
-        },
-        {
-            "source": "arxiv",
-            "term": "Theory-HEP"
-        },
-        {
-            "source": "arxiv",
+            "source": "curator",
             "term": "Theory-Nucl"
+        },
+        {
+            "source": "arxiv",
+            "term": "General Physics"
+        },
+        {
+            "source": "curator",
+            "term": "General Physics"
         }
     ],
     "name": {
-        "numeration": "II",
-        "preferred_name": "m",
-        "title": "Sir",
-        "value": "?EWn,V Kj~*, $#*"
+        "numeration": "Jr.",
+        "preferred_name": "deserunt",
+        "title": "",
+        "value": "rr.\\)n, N4%rF-<0vVB"
     },
     "native_name": [
-        "anim ",
-        "Ut",
-        "culpa sit veniam cillum nostrud",
-        "ullamco"
+        "in do adipisicing Duis",
+        "irure",
+        "in eu",
+        "velit ut"
     ],
     "new_record": {
-        "$ref": "http://1R|p"
+        "$ref": "http://1VL>k_"
     },
     "other_names": [
-        "officia nulla",
-        "nost",
-        "ut mollit",
-        "Duis Lorem esse culpa minim"
+        "ad in D"
     ],
     "past_emails_addresses": [
-        "7LDFjusb1b1-oEj@sgTZVgVy.rek"
+        "6Q0yJxv6hZdV@XSlF.abf",
+        "ZsvC-HgFdUxYOO@vEBq.gzl"
     ],
     "positions": [
         {
-            "_rank": "laboris et dolor non consequat",
+            "_rank": "ea dolor veniam",
             "current": false,
             "emails": [
-                "a12Di@N.imre",
-                "VbmJhF@WdGXV.sho",
-                "UN4@zVfnyoDisZwtvKCamaJJMw.lw",
-                "UixWtnvy6rqGEyn@cumGWRevzuyokqapBVv.hme"
-            ],
-            "end_date": "dddd-dd-dd",
-            "institution": {
-                "curated_relation": true,
-                "name": "est",
-                "record": {
-                    "$ref": "http://1CEnXW"
-                }
-            },
-            "old_emails": [
-                "1zEI@pDqTTawrDpr.xzhp",
-                "emDZ-KL39lL7jK@HjAdLxHid.ic",
-                "oWh@kwTEDEMEtQTe.faus",
-                "zyDCr9Lr3Wn@THDdwXWOkxZni.rdg",
-                "qBfLXpdP-YYQ4@kjrcNTbKNWoszZVBRWyNWzRtiUqVdIg.ufom"
-            ],
-            "rank": "VISITOR",
-            "start_date": "dddd-dd-dd"
-        },
-        {
-            "_rank": "Lorem in occaecat laboris",
-            "current": true,
-            "emails": [
-                "yRp3ilApr@EIkZorzPYPMGJfcIrNErUKtEY.pe"
+                "pB-ZSM7Ai-YUqva@ilZNIgDw.fu"
             ],
             "end_date": "dddd-dd-dd",
             "institution": {
                 "curated_relation": false,
-                "name": "aute",
+                "name": "dolore anim ullamco incididunt Ut",
                 "record": {
-                    "$ref": "http://1,ac"
+                    "$ref": "http://1hv\"ZQl-`>C"
                 }
             },
             "old_emails": [
-                "cYLf0cxwN@AiTYcmePTnGljEYLgffoBwAhck.xp",
-                "Uu0uN@VeDlllmGUfDiDWkvEaDiIgBJK.ii",
-                "juKaw@SsxcOTjyNGEdGvBUJu.ag",
-                "r2otW9ycvbbl@KZnQixCnCQKGdtgRvFjcmW.yio"
+                "IJHfZUE@zULHKjHIEkMArhBxvEBk.ryhe",
+                "01Fc13h8CmD@SlsjnZuXKXkIsLL.vlz",
+                "jtd@K.yybv",
+                "OfG@PT.si"
             ],
-            "rank": "VISITOR",
+            "rank": "UNDERGRADUATE",
             "start_date": "dddd-dd-dd"
         },
         {
-            "_rank": "in nulla",
-            "current": true,
+            "_rank": "n",
+            "current": false,
             "emails": [
-                "oXRmqEw@fIgCIMMmKXFXSyfLX.zcd",
-                "vfxG@qPOGFOFUdUD.wt",
-                "cgVk98aOn@CoVBImaBeEuJcmISAd.wl",
-                "G3oTqnsvPUFz@xCRyLfeKEUcsQh.weg",
-                "G4MGnM@Wim.kin"
+                "UyWSaAAsjR@ELUynWiN.eu",
+                "t2CT@owSeUtTjaLYkBHnvgvNm.lz",
+                "oMzzhBHqRqtETGO@zATEqxkVtRHbPaFFrDrCKoyggK.ehad",
+                "aDDfdghD-ukEO@cFUonPISjNA.ec"
             ],
             "end_date": "dddd-dd-dd",
             "institution": {
                 "curated_relation": true,
-                "name": "cupidatat culpa laboris",
+                "name": "reprehenderit velit dolore",
                 "record": {
-                    "$ref": "http://1]JC"
+                    "$ref": "http://19&o?."
                 }
             },
             "old_emails": [
-                "SPg0Mz@Azq.oxyu",
-                "poJb5V9s0@fHSAMQoyVxbuOEOTZAgvlYpOpWBpQqFp.cerp",
-                "YThKMf@XUUexyhOhVXrZQvylNI.qc"
+                "7ObcsSMhAg@SiqMTsbHMdPlgzfUEuhOTUGRdub.ss",
+                "bLrNKh29pqN@qZALUgBMtwpElXlWCFVYLBrIjTCCZxuR.usk",
+                "9eQh4Ga@okaAqElsWiHbgWtlLA.izog",
+                "tXk38x1bkt@rKzbeGZzAOeNAOiMMpAIVkfo.is",
+                "yCjFaR@eZWAQrvGcnjBRUPBcqzSyfMxVcWOlWm.bs"
             ],
-            "rank": "MASTER",
+            "rank": "JUNIOR",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "elit do consequat nostrud",
+            "current": false,
+            "emails": [
+                "ugwVjU0Jmt@EbgyAPLyUuYGlt.svb",
+                "x9bOD5@MPCFvMaEOiWakAJkbwzLJTVtoAaTAO.pnt"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "minim Ut",
+                "record": {
+                    "$ref": "http://1-z- wKV9s"
+                }
+            },
+            "old_emails": [
+                "XggGbnbjqDK@BKyVkNxsyWELtlkqfvmiYGkJ.ju"
+            ],
+            "rank": "STAFF",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "eiusmod incididunt consequat mollit a",
+            "current": false,
+            "emails": [
+                "ohDOHRqNfkNQ@R.wcr",
+                "T4D084@JxfPTNnbEOFplGlFdQGB.xafw",
+                "rIrDU8FOxcRKYC@nGHVKBcFWnZcqIwnwtfSmOaK.lpb",
+                "2TiYDqUH@RmxEqBJ.ivo"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "Lorem",
+                "record": {
+                    "$ref": "http://19oYSOn9"
+                }
+            },
+            "old_emails": [
+                "fD7PFFv-0ZU44M@rbEbCpJznDxvG.dqd",
+                "bUosyC@xAQ.feu",
+                "HpaqdE@iIEXzwKkEAcAOttJdALOmTFIKpKvlUQgy.ous",
+                "JqXrRfif@Lmhy.vgem"
+            ],
+            "rank": "SENIOR",
             "start_date": "dddd-dd-dd"
         }
     ],
     "previous_names": [
-        "aliqua adipisicing do",
-        "in",
-        "dolore",
-        "dolor ut volup",
-        "sunt aliqua occaecat ipsum"
+        "a",
+        "exercitation",
+        "aliqua",
+        "commodo proident velit consectetur"
     ],
     "prizes": [
-        "sunt",
-        "reprehenderit consectetur proident adipisicing",
-        "occaecat ipsum eu sunt nisi",
-        "aliquip veniam eu",
-        "ipsum adipisicing labore"
+        "ut quis irure eiusmod adipisicing"
     ],
     "public_notes": [
         {
-            "source": "",
-            "value": "est mollit"
+            "source": "tempor esse aliqua magna cupidatat",
+            "value": "elit"
         },
         {
-            "source": "occaecat",
-            "value": "aliquip fugiat Ut consequat"
+            "source": "sed",
+            "value": "est"
         },
         {
-            "source": "deserunt dolore velit ad",
-            "value": "labore"
+            "source": "Ut ut ea",
+            "value": "exercitation id"
         },
         {
-            "source": "amet",
-            "value": "nostrud adipisicing fugiat ea"
+            "source": "Excepteur eiusmod voluptate velit Lorem",
+            "value": "ipsum enim cillum"
+        },
+        {
+            "source": "eu sint sunt quis dolor",
+            "value": "dolore sint"
         }
     ],
     "self": {
-        "$ref": "http://1*HW"
+        "$ref": "http://1(4lOrB"
     },
     "source": [
         {
             "date_verified": "dddd-dd-dd",
-            "name": "sunt dolor"
+            "name": "aliquip culpa minim proident velit"
         },
         {
             "date_verified": "dddd-dd-dd",
-            "name": "laboris fugiat tempor incididunt"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "irure mollit i"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "non proident"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "exercitation ipsum"
+            "name": "ut sint i"
         }
     ],
-    "status": "retired",
+    "status": "deceased",
+    "stub": false,
     "urls": [
         {
-            "description": "commodo pariatur sed",
-            "value": "http://14P"
-        },
-        {
-            "description": "velit dolor culpa sint",
-            "value": "http://1!O"
-        },
-        {
-            "description": "eu dolore ut eiusmod reprehenderit",
-            "value": "http://1cu\\r0pTB"
-        },
-        {
-            "description": "consectetur in elit",
-            "value": "http://1$f^bT"
-        },
-        {
-            "description": "minim",
-            "value": "http://1;h<!AIP;8a"
+            "description": "labore nisi ut",
+            "value": "http://1Ima"
         }
     ]
 }

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -270,11 +270,6 @@
             "value": "Lorem"
         }
     ],
-    "collections": [
-        {
-            "primary": "velit dolor consectetur pa"
-        }
-    ],
     "control_number": 95311308,
     "copyright": [
         {
@@ -1228,7 +1223,7 @@
     "self": {
         "$ref": "http://1xZsQ)+fgs"
     },
-    "special_collection": [
+    "special_collections": [
         "ZEUS-PRELIMINARY-NOTE",
         "D0-INTERNAL-NOTE"
     ],


### PR DESCRIPTION
* INCOMPATIBLE kills collections for hep and authors.

    - In hep, collections have been superseded by document_type,
    publication_type, citeable, refereed, special_collections.

    -For authors, it is completely useless as the existing values on
    legacy are 'USEFUL' and 'HEPNAMES', both of which have special
    meaning.

* INCOMPATIBLE also pluralizes special_collections, which is an array.

Signed-off-by: Micha Moskovic <michamos@gmail.com>