### PR TITLE
hep: add hidden report numbers

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -688,7 +688,22 @@
         },
         "report_numbers": {
             "items": {
-                "$ref": "elements/sourced_value.json"
+                "additionalProperties": false,
+                "properties": {
+                    "hidden": {
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "$ref": "elements/source.json"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "value"
+                ],
+                "type": "object"
             },
             "type": "array",
             "uniqueItems": true


### PR DESCRIPTION
* NEW adds hidden key to report_numbers, to mark the report numbers that
need to be indexed and searchable, but not displayed to the user.

Signed-off-by: Micha Moskovic <michamos@gmail.com>