### PR TITLE
hep: require at least one arXiv category

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -61,7 +61,9 @@
                         "items": {
                             "$ref": "elements/arxiv_categories.json"
                         },
-                        "type": "array"
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
                     },
                     "value": {
                         "description": "arXiv eprint number, e.g. math.DG/0307245 or 1701.01431",
@@ -70,6 +72,7 @@
                     }
                 },
                 "required": [
+                    "categories",
                     "value"
                 ],
                 "type": "object"


### PR DESCRIPTION
* INCOMPATIBLE adds "categories" to the required keys of "arxiv_eprints"
and force it to have at least one element.

Signed-off-by: Micha Moskovic <michamos@gmail.com>