### PR TITLE
elements: add thesis to degree_type

### DIFF
--- a/inspire_schemas/records/elements/degree_type.json
+++ b/inspire_schemas/records/elements/degree_type.json
@@ -7,7 +7,8 @@
         "laurea",
         "master",
         "phd",
-        "habilitation"
+        "habilitation",
+        "thesis"
     ],
     "title": "Degree type",
     "type": "string"


### PR DESCRIPTION
* Adds missing `thesis` to `degree_type.json` element.

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>