### PR TITLE
general: new legacy_creation_date

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -128,6 +128,10 @@
             "type": "array",
             "uniqueItems": true
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "name": {
             "additionalProperties": false,
             "description": "Contains name information.",

--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -88,6 +88,10 @@
             "type": "array",
             "uniqueItems": true
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "new_record": {
             "$ref": "elements/json_reference.json",
             "description": "Master record that replaces this record",

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -134,6 +134,10 @@
             "type": "array",
             "uniqueItems": true
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "new_record": {
             "$ref": "elements/json_reference.json",
             "description": "Master record that replaces this record",

--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -552,6 +552,10 @@
             },
             "type": "array"
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "license": {
             "items": {
                 "additionalProperties": false,

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -133,6 +133,10 @@
             "title": "Institution acronym",
             "type": "string"
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "location": {
             "additionalProperties": false,
             "properties": {

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -104,6 +104,10 @@
             "type": "array",
             "uniqueItems": true
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "new_record": {
             "$ref": "elements/json_reference.json",
             "description": "Master record that replaces this record",

--- a/inspire_schemas/records/journals.json
+++ b/inspire_schemas/records/journals.json
@@ -79,6 +79,10 @@
             "type": "array",
             "uniqueItems": true
         },
+        "legacy_creation_date": {
+            "format": "date-time",
+            "type": "string"
+        },
         "license": {
             "enum": [
                 "probably",

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -1,275 +1,379 @@
 {
     "_collections": [
-        "culpa Excepteur Ut",
-        "aliqua amet voluptate",
-        "dolore",
-        "sint eius"
+        "ut pariatur occaecat ipsum dolore",
+        "dolore sit"
     ],
     "_private_notes": [
         {
-            "source": "dolor culpa laboris",
-            "value": "a"
+            "source": "cillum",
+            "value": "ut dolor"
+        },
+        {
+            "source": "est aliqua in Duis pariatur",
+            "value": "la"
+        },
+        {
+            "source": "ipsum elit in incididunt Ut",
+            "value": "reprehenderit sit aute"
+        },
+        {
+            "source": "nostrud",
+            "value": "quis irure mollit"
+        },
+        {
+            "source": "laboris dolore do quis ut",
+            "value": "Exc"
         }
     ],
     "acquisition_source": {
-        "date": "sit quis consequat irure",
-        "email": "Byo0isSgyKRIk@EkvILJBZhmiBsjlHxcRXhwBZupWYEd.vck",
-        "internal_uid": 17776566,
-        "method": "oai",
-        "orcid": "3268-4082-2677-2877",
-        "source": "amet cupidatat eiusmod in",
-        "submission_number": "consequat consectetur"
+        "date": "fugiat Lorem",
+        "email": "Flyk8lAu@wXINvsDGfCZvJetosakZGiBbqXK.ef",
+        "internal_uid": 57643566,
+        "method": "submitter",
+        "orcid": "1579-9778-0717-8588",
+        "source": "quis in enim proident et",
+        "submission_number": "anim sint"
     },
     "advisors": [
         {
-            "curated_relation": false,
+            "curated_relation": true,
             "degree_type": "bachelor",
             "ids": [
                 {
-                    "type": "CERN",
-                    "value": "CERN-15524"
+                    "type": "WIKIPEDIA",
+                    "value": "0"
                 },
                 {
-                    "type": "CERN",
-                    "value": "CERN-2426545"
+                    "type": "WIKIPEDIA",
+                    "value": "Eiih0rT_AF"
                 },
                 {
-                    "type": "CERN",
-                    "value": "CERN-219919"
+                    "type": "WIKIPEDIA",
+                    "value": "KOCn8_MX"
                 },
                 {
-                    "type": "CERN",
-                    "value": "CERN-8969"
-                },
-                {
-                    "type": "CERN",
-                    "value": "CERN-370436"
+                    "type": "WIKIPEDIA",
+                    "value": "g8"
                 }
             ],
-            "name": "",
+            "name": "Ut culpa",
             "record": {
-                "$ref": "http://1OM"
+                "$ref": "http://16.u(W#6"
             }
         },
         {
             "curated_relation": true,
-            "degree_type": "other",
+            "degree_type": "master",
             "ids": [
                 {
-                    "type": "CERN",
-                    "value": "CERN-2164339722"
-                },
-                {
-                    "type": "CERN",
-                    "value": "CERN-15849361"
-                },
-                {
-                    "type": "CERN",
-                    "value": "CERN-71684045"
+                    "type": "WIKIPEDIA",
+                    "value": "JEyRAT"
                 }
             ],
-            "name": "qui ea dolore nulla",
+            "name": "ea do anim",
             "record": {
-                "$ref": "http://1t1B2*J"
-            }
-        },
-        {
-            "curated_relation": false,
-            "degree_type": "bachelor",
-            "ids": [
-                {
-                    "type": "CERN",
-                    "value": "CERN-5975189993"
-                },
-                {
-                    "type": "CERN",
-                    "value": "CERN-719"
-                },
-                {
-                    "type": "CERN",
-                    "value": "CERN-03"
-                }
-            ],
-            "name": "dolor",
-            "record": {
-                "$ref": "http://1|"
+                "$ref": "http://1p,c"
             }
         },
         {
             "curated_relation": true,
-            "degree_type": "diploma",
+            "degree_type": "laurea",
             "ids": [
                 {
-                    "type": "CERN",
-                    "value": "CERN-222840048"
+                    "type": "WIKIPEDIA",
+                    "value": "lqzQgTa"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "7llXKdc"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "yVwB"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "71jKiqqg"
                 }
             ],
-            "name": "in quis",
+            "name": "minim veniam occaecat Lorem",
             "record": {
-                "$ref": "http://1"
+                "$ref": "http://1XLcr"
+            }
+        },
+        {
+            "curated_relation": false,
+            "degree_type": "master",
+            "ids": [
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "TVys_mm"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "74RG9p"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "7d"
+                },
+                {
+                    "type": "WIKIPEDIA",
+                    "value": "TXkZOmiJX"
+                }
+            ],
+            "name": "in aliqua",
+            "record": {
+                "$ref": "http://1YH94c"
             }
         }
     ],
     "birth_date": "dddd-dd-dd",
     "conferences": [
         {
-            "$ref": "http://1"
-        },
-        {
-            "$ref": "http://1X"
-        },
-        {
-            "$ref": "http://1EPYE"
-        },
-        {
-            "$ref": "http://1Ju`Py[]'M("
+            "$ref": "http://1T"
         }
     ],
-    "control_number": 51310738,
+    "control_number": 57408640,
     "death_date": "dddd-dd-dd",
-    "deleted": true,
+    "deleted": false,
     "email_addresses": [
-        "7aaqfgr24j@pkV.aduh",
-        "3vreu@WI.xxje",
-        "tt77i1aCNNEH@DgNxGqpLfKHoBFioqBwGqlALwhPv.gr",
-        "bBixPkIALJF@ozaJjiWtbohcDdDAHEwKGAbH.scdz"
+        "mkFdBj@Gh.fp",
+        "mKRpvK@GCGtEBIgO.ew",
+        "NkGZI@d.mkp"
     ],
     "experiments": [
         {
+            "curated_relation": false,
+            "current": false,
+            "end_year": -50633959,
+            "name": "fugiat",
+            "record": {
+                "$ref": "http://1?J_ ["
+            },
+            "start_year": -8473451
+        },
+        {
+            "curated_relation": true,
+            "current": true,
+            "end_year": 60888718,
+            "name": "quis esse",
+            "record": {
+                "$ref": "http://14;UMb[CnQ"
+            },
+            "start_year": -35581882
+        },
+        {
             "curated_relation": true,
             "current": false,
-            "end_year": -94513459,
-            "name": "aliqua dolor",
+            "end_year": 58650121,
+            "name": "nulla reprehenderit ex qui",
             "record": {
-                "$ref": "http://1m7lV?k8"
+                "$ref": "http://1"
             },
-            "start_year": 73363538
+            "start_year": -53133188
+        },
+        {
+            "curated_relation": true,
+            "current": true,
+            "end_year": 59872675,
+            "name": "eu id dolor irure",
+            "record": {
+                "$ref": "http://1\\{yI"
+            },
+            "start_year": -16593428
+        },
+        {
+            "curated_relation": false,
+            "current": false,
+            "end_year": 89087292,
+            "name": "minim cillum do",
+            "record": {
+                "$ref": "http://1T74"
+            },
+            "start_year": -52675076
         }
     ],
     "ids": [
         {
             "type": "CERN",
-            "value": "CERN-9886455"
+            "value": "CERN-0"
         },
         {
             "type": "CERN",
-            "value": "CERN-47876726498"
+            "value": "CERN-535712"
         }
     ],
     "inspire_categories": [
         {
             "source": "undefined",
-            "term": "Experiment-Nucl"
-        },
-        {
-            "source": "undefined",
-            "term": "General Physics"
-        },
-        {
-            "source": "magpie",
-            "term": "Accelerators"
+            "term": "Lattice"
         }
     ],
+    "legacy_creation_date": "3273-10-28T08:20:31.914Z",
     "name": {
-        "numeration": "IV",
-        "preferred_name": "exercitation dolor",
+        "numeration": "VIII",
+        "preferred_name": "dolor consectetur dolore sint",
         "title": "Sir",
-        "value": "uR-#L,,z, 4QywSlY"
+        "value": "S|`!, H"
     },
     "native_name": [
-        "est anim tempor",
-        "nisi reprehenderit adipisicing ut enim",
-        "in Duis commodo",
-        "Exc"
+        "incididunt esse"
     ],
     "new_record": {
-        "$ref": "http://1"
+        "$ref": "http://1Uw;4r=S"
     },
     "other_names": [
-        "id",
-        "magna occaecat"
+        "aliquip Duis qui ut commodo",
+        "sunt est in irure ad"
     ],
     "past_emails_addresses": [
-        "oDBsk@UriuOKsKxRpmQlv.tanx",
-        "22LUTtBLAYtpm@lgkFbUMFSwiybVIhu.wka"
+        "cm0dkgivD@nsvUBGnDnjquBcIfxTqXE.li",
+        "8qm@Ba.hsd",
+        "ukALGeXMVasqg@O.cbq",
+        "v6JEkGVrEG@fD.bsv",
+        "quZZYZWyH@eSitgGetNBXhNfceZGLU.jr"
     ],
     "positions": [
         {
-            "_rank": "id",
+            "_rank": "nisi reprehenderit",
             "current": false,
             "emails": [
-                "eA0k0QUGD@JhSk.fwmd",
-                "ZBiOZFbq@fCTfUXweiHgDNgz.ys",
-                "DWBxbZe7clS7C@vrsigeURRuZPqASyOObNBiELByIPDVYno.vh",
-                "TOU1qTNvLit@AMSlkbhJsNdRaLyHFbvdyvIwXNZq.xy"
+                "3vdpkfw@oVfhZzyCTX.dwse",
+                "4XLrVqMHT@Kt.szz",
+                "ZTCaA@MszdvWzw.sbo",
+                "YX47VRGP6VLonzA@vkqct.pcs"
             ],
             "end_date": "dddd-dd-dd",
             "institution": {
-                "curated_relation": true,
-                "name": "esse minim dolore",
+                "curated_relation": false,
+                "name": "cupidatat esse proident labore et",
                 "record": {
-                    "$ref": "http://17U"
+                    "$ref": "http://1"
                 }
             },
             "old_emails": [
-                "9NjLyR5f@tJzGgDks.pfyg",
-                "TSBxhO@qxCsZGNwrEfSKpYNpQKWnp.kk",
-                "TJnh4k7QDox5@LQcHkbbOpcwAIXcNzmtbwGfUkRIaZ.kz",
-                "ahnE-vcr19mc@yXEmZSMscSUTMVgzoEDkP.hx",
-                "f0ZY-43@ANYlOrEKpyLrsxgkANZN.uz"
+                "M8r5sLGtc9vRR@i.lilx"
+            ],
+            "rank": "STAFF",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "cillum",
+            "current": true,
+            "emails": [
+                "WQwMoYJ@Y.dwp"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "enim labore ea elit pariatur",
+                "record": {
+                    "$ref": "http://1=^~J o"
+                }
+            },
+            "old_emails": [
+                "dQr@E.ixnu",
+                "QhVYoN9Tg@LMvNyTwoJBv.gtc",
+                "7Q1UuQ64-F@nrvGxnjPUyvNQfFsjwzrKqFaUA.xd",
+                "GPKHoyMwiSe@yBwCQHINctWu.gg",
+                "B97b2aX5uu@kEWxOXPSh.fv"
+            ],
+            "rank": "UNDERGRADUATE",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "ad occaecat",
+            "current": true,
+            "emails": [
+                "NiX@OKyDBLihSGtfev.gao",
+                "KieUjf2ao@QcJjWxBemjAyCXDZoWSV.vwso",
+                "hQGYxbW@ZKhRsFiZgnLoblLyUWXHqfiasUMVh.io"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "eiusmod",
+                "record": {
+                    "$ref": "http://1=["
+                }
+            },
+            "old_emails": [
+                "hyMj2WoG@TSWymYdonPuHf.pptd",
+                "UoMNRAK@MCYPDoiAzPGmYaGBWcQbKWqOkmt.dcql"
             ],
             "rank": "VISITOR",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "labore",
+            "current": true,
+            "emails": [
+                "ZCRe9XbDPzT1di@xjXQpgdnctPDTeXyOOdP.vgp"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "eu",
+                "record": {
+                    "$ref": "http://1i/Yo"
+                }
+            },
+            "old_emails": [
+                "KwoW2yrYAQV3@wUdWxcMAWFtnZFmmkPHauRjNJeEou.apw",
+                "EfHVsiahAZJjO@Fj.lvxk"
+            ],
+            "rank": "SENIOR",
             "start_date": "dddd-dd-dd"
         }
     ],
     "previous_names": [
-        "sed v",
-        "minim aute dolore"
+        "Duis"
     ],
     "prizes": [
-        "aliqua tempor",
-        "",
-        "tempor commodo officia ipsum aliqua",
-        "qui nulla reprehenderit Duis",
-        "elit in Excepteur in"
+        "ad in non occaecat",
+        "do in aute qui ipsum",
+        "in ad nostrud",
+        "nulla quis mollit dolor",
+        "quis fugiat dolore pariatur ut"
     ],
     "public_notes": [
         {
-            "source": "magna cillum enim nulla eiusmod",
-            "value": "cupidatat"
+            "source": "enim incididunt eu",
+            "value": "reprehenderit"
         }
     ],
     "self": {
-        "$ref": "http://1?}2SW"
+        "$ref": "http://17.i=5u#rHO"
     },
     "source": [
         {
             "date_verified": "dddd-dd-dd",
-            "name": "velit do"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "esse Excepteur cillum in enim"
+            "name": "in"
         }
     ],
-    "status": "retired",
+    "status": "active",
     "stub": true,
     "urls": [
         {
-            "description": "aliquip",
-            "value": "http://1U-2kRV)|"
+            "description": "officia ipsum do",
+            "value": "http://1fqI4n"
         },
         {
-            "description": "mollit ea sunt",
-            "value": "http://1b~`]"
+            "description": "laboris tempor eiusmod cillum consequat",
+            "value": "http://1_`!It"
         },
         {
-            "description": "laborum cupidatat pariatur",
-            "value": "http://1Wu]XU"
+            "description": "mollit nostrud sunt",
+            "value": "http://1Ss&;hNTQ"
         },
         {
-            "description": "quis ut",
-            "value": "http://1b_N?Fj8Ii"
+            "description": "labore Lorem Excepteur in ",
+            "value": "http://1:Lu^"
+        },
+        {
+            "description": "sunt voluptate",
+            "value": "http://1NJ"
         }
     ]
 }

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -1,205 +1,218 @@
 {
     "_collections": [
-        "dolor ex qui Duis",
-        "dolore cillum dolor aute",
-        "et qui cupidatat"
+        "do voluptate reprehenderit laboris aliquip",
+        "in laboris"
     ],
     "_private_notes": [
         {
-            "source": "ut aute ipsum in",
-            "value": "laboris non Ut"
+            "source": "est",
+            "value": "nulla consectetur"
+        },
+        {
+            "source": "eiusm",
+            "value": "ad ut proident Duis"
+        },
+        {
+            "source": "incididunt voluptate in",
+            "value": "non Ut"
         }
     ],
     "acronym": [
-        "laboris Duis commodo",
-        "exercita",
-        "sit dolor esse Excepteur non",
-        "id veniam",
-        "enim"
+        "exercitation",
+        "occaecat Ut",
+        "au",
+        "qui"
     ],
     "address": [
         {
-            "city": "sint consectetur laboris ",
-            "country_code": "TJ",
-            "latitude": 65243847,
-            "longitude": -70683125,
-            "original address": "consectetur nostrud veniam",
-            "postal_code": "anim et tempor",
-            "state": "proident mollit"
-        },
-        {
             "city": "nulla",
-            "country_code": "AT",
-            "latitude": 91503764,
-            "longitude": 67715347,
-            "original address": "eiu",
-            "postal_code": "nisi est anim ullamco",
-            "state": "non"
-        },
-        {
-            "city": "dolore",
-            "country_code": "KP",
-            "latitude": 76096650,
-            "longitude": 72226550,
-            "original address": "fugiat",
-            "postal_code": "exercitation",
-            "state": "a"
-        },
-        {
-            "city": "consequat",
-            "country_code": "NE",
-            "latitude": -69969737,
-            "longitude": -92262170,
-            "original address": "u",
-            "postal_code": "labor",
-            "state": "tempor sunt reprehenderit sit cupidatat"
-        },
-        {
-            "city": "dolore",
-            "country_code": "DE",
-            "latitude": 90984715,
-            "longitude": -73306162,
-            "original address": "quis fugiat Ut voluptate",
-            "postal_code": "sit dolor irure dolor",
-            "state": "laborum tempor adipisicing laboris dolore"
+            "country_code": "CR",
+            "latitude": -94582302,
+            "longitude": 68060363,
+            "original address": "qui consectetur",
+            "postal_code": "in sunt exercitation ullamco",
+            "state": "anim velit non"
         }
     ],
     "alternative_titles": [
         {
-            "source": "voluptate qui ven",
-            "subtitle": "quis",
-            "title": "mollit"
+            "source": "nulla labore",
+            "subtitle": "elit aliqua aliquip et laboris",
+            "title": "d"
         },
         {
-            "source": "consectetur reprehenderit voluptate",
-            "subtitle": "Ex",
-            "title": "veniam ullamco in"
+            "source": "id",
+            "subtitle": "Duis amet qui in",
+            "title": "Lorem lab"
         },
         {
-            "source": "consectetur officia anim mollit",
-            "subtitle": "nisi Duis",
-            "title": "labore commodo aute"
+            "source": "occaecat laborum pariatur officia nulla",
+            "subtitle": "nisi ipsum incididunt dolor",
+            "title": "ad adipisicing "
+        },
+        {
+            "source": "consequat in proident",
+            "subtitle": "i",
+            "title": "cupidatat"
+        },
+        {
+            "source": "ut qui do ullamco commodo",
+            "subtitle": "nisi sed",
+            "title": "officia "
         }
     ],
     "closing_date": "dddd-dd-dd",
-    "cnum": "C31-45-55.026051",
+    "cnum": "C12-01-57",
     "contact_details": [
         {
-            "email": "zSwnOW-i02J@sgvcDIBUqTmzcCQAyRRY.tjsc",
-            "name": "ad"
+            "email": "1eXM6bJf1pt@uVgfkhMXaBcGElyftMGyMDgfgWgTv.cxo",
+            "name": "aute"
         },
         {
-            "email": "oFAcs0MfW@kqvmJyJCpDNnobj.krf",
-            "name": "quis labore cillum sit"
+            "email": "tkTLvt@TndxVpxngaMgu.vnp",
+            "name": "pariatur aliqua voluptate labore amet"
         },
         {
-            "email": "l97Zlc@lvrKrIbisnYmgJAxL.fu",
-            "name": "quis"
+            "email": "ZlGn@wTmRBLBNwjknwaofpNWJiNuBsymXx.ln",
+            "name": "aliqua qui"
+        },
+        {
+            "email": "AVjkysAesvw@zljiAcfdhbOBAtScRvFXoUiPMQiIWmgC.cl",
+            "name": "occaecat ea nulla eu incididunt"
+        },
+        {
+            "email": "0Dg7Noy@hPQVAlucKNPdapmLylCu.ivdb",
+            "name": "id laborum laboris"
         }
     ],
-    "control_number": -20304479,
-    "deleted": true,
+    "control_number": 66878112,
+    "deleted": false,
     "inspire_categories": [
         {
-            "source": "undefined",
-            "term": "General Physics"
+            "source": "arxiv",
+            "term": "Experiment-Nucl"
         },
         {
-            "source": "user",
-            "term": "Other"
+            "source": "curator",
+            "term": "Astrophysics"
+        },
+        {
+            "source": "magpie",
+            "term": "Math and Math Physics"
+        },
+        {
+            "source": "arxiv",
+            "term": "Data Analysis and Statistics"
         }
     ],
     "keywords": [
         {
-            "source": "fugiat",
-            "value": "Excepteur esse consequat"
-        },
-        {
-            "source": "ex Ut sit dolor dolore",
-            "value": "incididunt eiusmod"
+            "source": "cillum ad officia enim sit",
+            "value": "nostrud consectetur"
         }
     ],
+    "legacy_creation_date": "2421-08-17T06:44:40.797Z",
     "new_record": {
-        "$ref": "http://1;L^wz>("
+        "$ref": "http://1{`1|u"
     },
     "opening_date": "dddd-dd-dd",
-    "place": "Y,`@ll:'Wt3h]3f",
+    "place": "],9}Y3Y,~l?O,dF6<J!2:j",
     "public_notes": [
         {
-            "source": "non",
-            "value": "cu"
+            "source": "ex",
+            "value": "ullamco veniam Lorem amet"
         }
     ],
     "self": {
-        "$ref": "http://1?i"
+        "$ref": "http://1y}XfYM>x"
     },
     "series": [
         {
-            "name": "nulla",
-            "number": -55093916
+            "name": "irure est ",
+            "number": -29267610
         },
         {
-            "name": "aliqua",
-            "number": 22798973
+            "name": "officia ut l",
+            "number": -52031366
         },
         {
-            "name": "minim",
-            "number": 54875438
+            "name": "labore in proident",
+            "number": 99690609
         },
         {
-            "name": "Ut",
-            "number": -65984068
+            "name": "consectetur ea Lorem",
+            "number": -60566926
         },
         {
-            "name": "aliqua ad in cillum",
-            "number": -78383569
+            "name": "elit",
+            "number": -16603367
         }
     ],
     "short_description": [
         {
-            "source": "sit nisi",
-            "value": "est"
+            "source": "veniam sed mollit ex",
+            "value": "dolore"
         },
         {
-            "source": "dolore veniam",
-            "value": "do sit velit nostrud"
+            "source": "occaecat dolore magna cillum",
+            "value": "occaecat quis consectetur"
+        },
+        {
+            "source": "fugiat qui",
+            "value": "deserunt nostrud occaecat exercitation ipsum"
+        },
+        {
+            "source": "enim dolore cupidatat Duis",
+            "value": "aliqua reprehenderit dolor veniam sed"
+        },
+        {
+            "source": "voluptate laboris labore ipsum",
+            "value": "ea anim reprehenderit sed"
         }
     ],
     "titles": [
         {
-            "source": "fugiat pariatur id",
-            "subtitle": "enim qui cillum magna",
-            "title": "adipisicing officia fugiat aute"
+            "source": "consequat",
+            "subtitle": "velit sint id voluptate",
+            "title": "dolore sit nulla esse"
         },
         {
-            "source": "qui aute officia proident cillum",
-            "subtitle": "elit pariatur",
-            "title": "qui sint sunt"
+            "source": "officia sed nulla",
+            "subtitle": "amet",
+            "title": "sed velit deserunt"
         },
         {
-            "source": "non sint",
-            "subtitle": "sit aute",
-            "title": "qui labore fugiat pariatur irure"
+            "source": "sit qui sed nisi minim",
+            "subtitle": "qui Excepteur",
+            "title": "dolore"
         },
         {
-            "source": "nisi aliquip est",
-            "subtitle": "culpa nisi anim cupidatat",
-            "title": "ex velit elit qui dolor"
+            "source": "dolore in dolor ut",
+            "subtitle": "in esse laboris",
+            "title": "Excepteur laborum ut anim"
         },
         {
-            "source": "esse aliqua ",
-            "subtitle": "ea incididunt anim",
-            "title": "commodo"
+            "source": "enim aute",
+            "subtitle": "consectetur adipisicing exercitation reprehenderit",
+            "title": "Excepteur officia sunt incididunt"
         }
     ],
     "urls": [
         {
-            "description": "tempor",
-            "value": "http://1l*@v"
+            "description": "commodo elit",
+            "value": "http://1s(fAjZdI"
         },
         {
-            "description": "laboris cillum",
-            "value": "http://1[~"
+            "description": "tempor",
+            "value": "http://1Fejj"
+        },
+        {
+            "description": "fugiat officia enim aute deserunt",
+            "value": "http://1%>J"
+        },
+        {
+            "description": "Ut veniam consectetur",
+            "value": "http://1&k~(r"
         }
     ]
 }

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -1,191 +1,200 @@
 {
     "_collections": [
-        "in",
-        "cillum minim officia laborum dolor"
+        "irure consectetur labore",
+        "veniam labore in ex",
+        "ex consectetur officia cupidatat magna",
+        "veniam id nostrud"
     ],
     "_private_notes": [
         {
-            "source": "sit ea quis Ut",
-            "value": "exercitation"
+            "source": "ullamco",
+            "value": "Duis dolore velit Ut"
         },
         {
-            "source": "laboris officia Ut",
-            "value": "et"
+            "source": "mo",
+            "value": "magna cupidatat qui"
         },
         {
-            "source": "exercitation",
-            "value": "dolor"
+            "source": "Ut nulla laborum laboris",
+            "value": "pariatur tempor"
+        },
+        {
+            "source": "aute voluptate do",
+            "value": "culpa consectetur irure nulla"
         }
     ],
-    "accelerator": "sit",
+    "accelerator": "non qui fugiat",
     "affiliations": [
         {
-            "curated_relation": true,
-            "name": "irure ad",
+            "curated_relation": false,
+            "name": "consequat par",
             "record": {
-                "$ref": "http://1_Ze9]?U"
+                "$ref": "http://1Nj"
+            }
+        },
+        {
+            "curated_relation": false,
+            "name": "ut nulla consequat",
+            "record": {
+                "$ref": "http://1HiG"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "officia quis ipsum",
+            "record": {
+                "$ref": "http://1KG2sFA}"
+            }
+        },
+        {
+            "curated_relation": false,
+            "name": "Duis minim do",
+            "record": {
+                "$ref": "http://1;O_M\"yL"
             }
         }
     ],
-    "collaboration": "id fugiat",
+    "collaboration": "ut aliqua dol",
     "collaboration_alternative_names": [
-        "fugiat",
-        "quis magna commodo"
+        "dolore Duis"
     ],
     "contact_details": [
         {
-            "email": "Otq5vM7z@HeItyLXUzmMICcyvlqoWNqw.qah",
-            "name": "proident dolor"
-        },
-        {
-            "email": "THpB40@YfKMKYhbfrlj.vojh",
-            "name": "ad in et"
-        },
-        {
-            "email": "Mv8zALaYhYvO@Mt.xmre",
-            "name": "dolore dolore in ipsum ex"
-        },
-        {
-            "email": "oslen@AkUqXJXZWAZyTyvQAr.lkgv",
-            "name": "et dolor in"
-        },
-        {
-            "email": "StiF9ecOXi@mLCuCekxftahUP.mjf",
-            "name": "amet anim nisi sit deserunt"
+            "email": "3IBoKSidUYc4w3O@nwbfraQUO.yr",
+            "name": "irure pariatur ad"
         }
     ],
-    "control_number": 4218361,
+    "control_number": 89865816,
     "curated_relation": true,
     "date_approved": "dddd-dd-dd",
     "date_cancelled": "dddd-dd-dd",
     "date_completed": "dddd-dd-dd",
     "date_proposed": "dddd-dd-dd",
     "date_started": "dddd-dd-dd",
-    "deleted": false,
+    "deleted": true,
     "description": [
-        "Lorem fugiat sunt tempor"
+        "laborum amet",
+        "in",
+        "magna est in fugiat",
+        "do adipisicing Lorem aute incididunt"
     ],
     "experiment_names": [
         {
-            "source": "Excepteur Lorem aute voluptate",
-            "subtitle": "officia aliqua adipisicing Ut deserunt",
-            "title": "cupidatat incididunt"
+            "source": "ut magna",
+            "subtitle": "cupidatat magna",
+            "title": "ea ut dolor"
         },
         {
-            "source": "dolor consequat in tempor deserunt",
-            "subtitle": "ad",
-            "title": "proi"
+            "source": "sint",
+            "subtitle": "in",
+            "title": "qui"
         },
         {
-            "source": "aliquip proident adipisicing in",
-            "subtitle": "Duis velit in in",
-            "title": "aliquip proident dolore"
+            "source": "in aute labore sed eiusmod",
+            "subtitle": "sunt in",
+            "title": "ex reprehenderit commodo"
+        },
+        {
+            "source": "officia",
+            "subtitle": "in ipsum",
+            "title": "Duis qui commod"
         }
     ],
     "free_keywords": [
-        "qui dolore elit nisi",
-        "Duis elit eiusmod Lorem",
-        "irure ad deserun"
+        "adipisicing consectetur aliqua dolor ipsum",
+        "Ut ex tempor esse culpa",
+        "in pariatur ut",
+        "Lorem esse elit tempor",
+        "eu nisi est ut"
     ],
-    "hidden_note": "ullamco",
+    "hidden_note": "ex",
     "inspire_categories": [
         {
-            "source": "user",
-            "term": "Experiment-HEP"
+            "source": "curator",
+            "term": "Phenomenology-HEP"
         },
         {
-            "source": "arxiv",
-            "term": "Experiment-HEP"
-        },
-        {
-            "source": "magpie",
+            "source": "curator",
             "term": "Lattice"
         },
         {
-            "source": "user",
-            "term": "Experiment-Nucl"
+            "source": "curator",
+            "term": "Data Analysis and Statistics"
+        },
+        {
+            "source": "arxiv",
+            "term": "Computing"
         }
     ],
+    "legacy_creation_date": "4358-08-15T23:25:25.328Z",
     "new_record": {
-        "$ref": "http://1"
+        "$ref": "http://1V"
     },
     "other_experiment_names": [
         {
-            "source": "tempor ut",
-            "subtitle": "adipisicing voluptate tempor non magna",
-            "title": "eiusmod sunt incididunt dolor amet"
-        },
-        {
-            "source": "irure proident ea enim quis",
-            "subtitle": "ex",
-            "title": "reprehenderit est exercitation in veniam"
-        },
-        {
-            "source": "et",
-            "subtitle": "culpa",
-            "title": "dolore"
-        },
-        {
-            "source": "in proident Duis ut ",
-            "subtitle": "ex",
-            "title": "dolor proident "
-        },
-        {
-            "source": "cillum",
-            "subtitle": "non adipisicing",
-            "title": "mollit est et Duis ut"
+            "source": "commodo",
+            "subtitle": "dolor",
+            "title": "consectetur anim nulla"
         }
     ],
     "public_notes": [
         {
-            "source": "pariatur ipsum commodo cillum",
-            "value": "sed minim"
+            "source": "Lorem do et",
+            "value": "non et dolor sit"
         },
         {
-            "source": "cillum exerc",
-            "value": "occaecat ut ea quis"
+            "source": "et amet in pariatur culpa",
+            "value": "amet deserunt"
         },
         {
-            "source": "laboris aute magna",
-            "value": "ullamco"
+            "source": "consectetur",
+            "value": "mollit sit Excepteur irure qui"
         }
     ],
     "related_experiments": [
         {
-            "curated_relation": true,
-            "name": "consequat Lorem in Excepteur velit",
+            "curated_relation": false,
+            "name": "tempor officia non",
             "record": {
-                "$ref": "http://12ce_TYdK"
+                "$ref": "http://1>"
             },
             "relation": "predecessor"
         },
         {
             "curated_relation": false,
-            "name": "aliquip fugiat Exc",
+            "name": "amet",
             "record": {
-                "$ref": "http://1cywh\\d"
+                "$ref": "http://1XCq"
+            },
+            "relation": "successor"
+        },
+        {
+            "curated_relation": true,
+            "name": "quis sunt laborum ipsum anim",
+            "record": {
+                "$ref": "http://1{+.j|"
             },
             "relation": "successor"
         },
         {
             "curated_relation": false,
-            "name": "in mollit aliquip tempor",
+            "name": "deserunt",
             "record": {
-                "$ref": "http://14W"
+                "$ref": "http://1"
             },
-            "relation": "predecessor"
+            "relation": "successor"
         },
         {
-            "curated_relation": false,
-            "name": "aliqua elit",
+            "curated_relation": true,
+            "name": "laborum",
             "record": {
-                "$ref": "http://1s9eI"
+                "$ref": "http://1KKWrH!w"
             },
-            "relation": "predecessor"
+            "relation": "successor"
         }
     ],
     "self": {
-        "$ref": "http://1h&G/&"
+        "$ref": "http://1n\\\"c+w9"
     },
     "spokespersons": [
         {
@@ -194,79 +203,107 @@
             "end_date": "dddd-dd-dd",
             "ids": [
                 {
-                    "type": "ARXIV",
-                    "value": "rLe_3291920"
-                },
-                {
-                    "type": "ARXIV",
-                    "value": "7_51899550554"
-                },
-                {
-                    "type": "ARXIV",
-                    "value": "gcYajfFrz1y_K_002193"
-                },
-                {
-                    "type": "ARXIV",
-                    "value": "B1p4OTcM_27950802574"
-                },
-                {
-                    "type": "ARXIV",
-                    "value": "1K0M7_w_85952"
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-73275242"
                 }
             ],
-            "name": "do anim eu non",
+            "name": "mollit in dolor",
             "record": {
-                "$ref": "http://1Fb+R"
+                "$ref": "http://1&0g"
+            },
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "curated_relation": false,
+            "current": true,
+            "end_date": "dddd-dd-dd",
+            "ids": [
+                {
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-34411014"
+                }
+            ],
+            "name": "velit ut",
+            "record": {
+                "$ref": "http://1oPC"
             },
             "start_date": "dddd-dd-dd"
         },
         {
             "curated_relation": true,
-            "current": false,
+            "current": true,
             "end_date": "dddd-dd-dd",
             "ids": [
                 {
-                    "type": "ARXIV",
-                    "value": "J9tlFJNko_S_68"
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-09754012"
                 },
                 {
-                    "type": "ARXIV",
-                    "value": "MKeHzS0M_22386629"
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-95109832"
+                },
+                {
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-80431762"
+                },
+                {
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-96728388"
+                },
+                {
+                    "type": "INSPIRE ID",
+                    "value": "INSPIRE-16759357"
                 }
             ],
-            "name": "Duis",
+            "name": "culpa dolor tempor",
             "record": {
-                "$ref": "http://1d6@A#y"
+                "$ref": "http://13''@,jx"
             },
             "start_date": "dddd-dd-dd"
         }
     ],
     "titles": [
         {
-            "source": "mollit",
-            "subtitle": "in laboris cupidatat ea proident",
-            "title": "reprehenderit fugiat enim dolore Ut"
+            "source": "Ut labore do",
+            "subtitle": "eu pariatur sunt in",
+            "title": "cupidatat sed irure"
         },
         {
-            "source": "ea occaecat nostrud nulla enim",
-            "subtitle": "et",
-            "title": "quis sed ad"
+            "source": "ullamco sint sed",
+            "subtitle": "proident n",
+            "title": "in cupidatat magna esse dolore"
         },
         {
-            "source": "proident eiusm",
-            "subtitle": "in",
-            "title": "enim aute dolor nisi eu"
+            "source": "amet a",
+            "subtitle": "non laboris proident",
+            "title": "in"
         },
         {
-            "source": "amet labore eiusmod",
-            "subtitle": "ea elit do dolor sint",
-            "title": "magna nostrud"
+            "source": "qui in ut amet",
+            "subtitle": "in ullamco Duis",
+            "title": "sint"
         }
     ],
     "urls": [
         {
-            "description": "Lorem fugiat enim veniam",
-            "value": "http://1es"
+            "description": "exercitati",
+            "value": "http://1\""
+        },
+        {
+            "description": "deserunt ad qui est culpa",
+            "value": "http://1nf//(:!Y"
+        },
+        {
+            "description": "cillum dolor consequat",
+            "value": "http://1("
+        },
+        {
+            "description": "pariatur ipsum ut fugiat velit",
+            "value": "http://1QzwFa)"
+        },
+        {
+            "description": "nisi tempor non",
+            "value": "http://1=R '9VKo"
         }
     ]
 }

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1,125 +1,163 @@
 {
     "_collections": [
-        "irure",
-        "anim",
-        "Duis veniam labore",
-        "voluptate"
+        "magna aliquip et incididunt dolor"
     ],
     "_fft": [
         {
             "comment": "cillum",
-            "creation_datetime": "2998-09-05T20:34:09.358Z",
-            "description": "dolor",
-            "filename": "Duis ut laboris sit",
+            "creation_datetime": "3750-12-30T22:13:49.144Z",
+            "description": "anim incididunt sunt in",
+            "filename": "nulla ",
             "flags": [
-                "laboris nulla dolore",
-                "elit consequat culpa adipisicing commodo",
-                "esse"
+                "consequat sit"
             ],
-            "format": "qui nulla dolore magna ex",
-            "path": "magna exercitation",
-            "status": "dolor",
-            "type": "ex adipisicing reprehenderit laboris in",
-            "version": 8599716
+            "format": "nulla",
+            "path": "culpa",
+            "status": "cupidatat deserunt qui dolore Lorem",
+            "type": "minim proident officia cupidatat",
+            "version": -53254378
+        },
+        {
+            "comment": "sed pariatur nisi",
+            "creation_datetime": "3981-06-17T10:44:54.262Z",
+            "description": "in et laboris incididunt ullamco",
+            "filename": "incididunt deserunt mo",
+            "flags": [
+                "enim commodo consequat dolore proident",
+                "sed reprehenderit nostrud esse proident",
+                "in qui dolor l"
+            ],
+            "format": "reprehenderit tempor sunt",
+            "path": "sint et commodo ipsum",
+            "status": "n",
+            "type": "sint",
+            "version": 28828782
+        },
+        {
+            "comment": "Duis nostrud reprehe",
+            "creation_datetime": "2971-02-18T12:45:31.505Z",
+            "description": "dolore nisi in",
+            "filename": "elit cupidatat do anim",
+            "flags": [
+                "sint dolore anim",
+                "sunt amet adipisicing",
+                "labore",
+                "sed"
+            ],
+            "format": "cupidatat deserunt laborum",
+            "path": "nostrud te",
+            "status": "aliquip amet dolore commodo pariatur",
+            "type": "non voluptate sit",
+            "version": -61699706
+        },
+        {
+            "comment": "consectetur reprehenderit nostrud ut",
+            "creation_datetime": "2373-12-16T21:36:35.389Z",
+            "description": "laborum aliquip aute in",
+            "filename": "",
+            "flags": [
+                "aliqua",
+                "fugiat dolor laboris eiusmod"
+            ],
+            "format": "do cillum deserunt veniam",
+            "path": "reprehenderit in",
+            "status": "commodo sed velit occaecat non",
+            "type": "Ut",
+            "version": 18550351
         }
     ],
     "_private_notes": [
         {
-            "source": "cupi",
-            "value": "a"
+            "source": "officia",
+            "value": "tempor eiusmod Lorem"
         },
         {
-            "source": "esse nulla aliqua dolor",
-            "value": "sint "
+            "source": "anim ea ipsum dolore",
+            "value": "aliqua velit in"
         },
         {
-            "source": "do non tempor",
-            "value": "elit Duis"
+            "source": "nisi",
+            "value": "adipisicing ex Excepteur do in"
         },
         {
-            "source": "dolore dolor",
-            "value": "consectetur incididunt"
+            "source": "velit occaecat est do pariatur",
+            "value": "Duis qui commodo mollit aute"
         }
     ],
     "abstracts": [
         {
-            "source": "sint ut quis in voluptate",
-            "value": "Lorem nostrud"
+            "source": "esse",
+            "value": "minim"
         },
         {
-            "source": "consectetur aliqua laboris proident",
-            "value": "in adipisicing ea aliqua"
+            "source": "sint ullamco deserunt minim",
+            "value": "laborum aliqua incididunt"
         },
         {
-            "source": "amet nulla sunt",
-            "value": "enim exercit"
+            "source": "culpa quis consequat veniam elit",
+            "value": "ea"
         }
     ],
     "accelerator_experiments": [
         {
-            "accelerator": "in culpa sunt",
-            "curated_relation": false,
-            "experiment": "in reprehenderit",
-            "institution": "ut aliquip deserunt",
-            "legacy_name": "ut Ut",
+            "accelerator": "irure",
+            "curated_relation": true,
+            "experiment": "elit",
+            "institution": "fugiat voluptate velit Excepteur aliqua",
+            "legacy_name": "in",
             "record": {
-                "$ref": "http://1"
+                "$ref": "http://1SO%g/_0rM"
             }
         },
         {
-            "accelerator": "deserunt Excepteur nulla",
-            "curated_relation": true,
-            "experiment": "fugiat",
-            "institution": "elit ut",
-            "legacy_name": "Duis eiusmod dolore",
+            "accelerator": "do sed",
+            "curated_relation": false,
+            "experiment": "anim in fugiat in enim",
+            "institution": "consequat commodo Ut ",
+            "legacy_name": "nisi reprehenderit ex tempor",
             "record": {
-                "$ref": "http://1%d1"
+                "$ref": "http://1|f,"
+            }
+        },
+        {
+            "accelerator": "sint occaecat Duis",
+            "curated_relation": false,
+            "experiment": "cillum laboris consequat",
+            "institution": "laboris eu",
+            "legacy_name": "deserunt non voluptate",
+            "record": {
+                "$ref": "http://1}5N.TC"
+            }
+        },
+        {
+            "accelerator": "eiusmod eu",
+            "curated_relation": true,
+            "experiment": "sunt Ut officia",
+            "institution": "quis esse voluptate eiusmod culpa",
+            "legacy_name": "ut",
+            "record": {
+                "$ref": "http://12<J$cp4Zv]"
             }
         }
     ],
     "acquisition_source": {
-        "date": "magna quis",
-        "email": "Fh1IVDJLQ@wMSURapwBsJfhdjmRrVEFRjChx.rm",
-        "internal_uid": -24095381,
-        "method": "hepcrawl",
-        "orcid": "7563-9208-3777-7491",
-        "source": "ex labore Lorem sunt",
-        "submission_number": "sint nulla"
+        "date": "labore ullamco consectetur enim",
+        "email": "WH7@NYgOaFOcQJs.sq",
+        "internal_uid": 38702570,
+        "method": "oai",
+        "orcid": "6529-1570-1948-5893",
+        "source": "labore enim culpa",
+        "submission_number": "ullamco"
     },
     "arxiv_eprints": [
         {
             "categories": [
-                "math.QA",
-                "alg-geom",
-                "cs.CL"
-            ],
-            "value": "jqy.hCy-x0rs6edkFsr/408"
-        },
-        {
-            "categories": [
-                "physics",
-                "physics.ins-det",
-                "physics.acc-ph",
-                "cond-mat.mes-hall",
-                "physics.class-ph"
-            ],
-            "value": "893952695"
-        },
-        {
-            "categories": [
+                "math.GM",
+                "q-fin.EC",
                 "math.CV",
-                "q-fin",
-                "cs",
-                "stat.TH"
+                "nlin.SI"
             ],
-            "value": "6266'81063"
-        },
-        {
-            "categories": [
-                "math.NT",
-                "q-fin.MF"
-            ],
-            "value": "Hb/7881682110"
+            "value": "UtZONnpWCW/301326152"
         }
     ],
     "authors": [
@@ -128,1554 +166,686 @@
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1\"YCzVXL1'v"
+                        "$ref": "http://1#BWcn3"
                     },
-                    "value": "nisi veniam"
+                    "value": "dolore exercitation"
                 },
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1Lz"
+                        "$ref": "http://1\\g0JTjQh\""
                     },
-                    "value": "nulla magn"
+                    "value": "proident aute nulla Lorem"
                 },
                 {
-                    "curated_relation": false,
+                    "curated_relation": true,
                     "record": {
-                        "$ref": "http://1\\^~/8y,{-Y"
+                        "$ref": "http://1P&qTsFrjP"
                     },
-                    "value": "adipisicing cillum sunt cupidatat"
+                    "value": "laboris magna ex fugiat Excepteur"
                 }
             ],
             "alternative_names": [
-                "officia laboris sit sed",
-                "dolore irure",
-                "Excepteur"
+                "do labore sed est laborum"
             ],
             "credit_roles": [
                 "Data curation",
-                "Resources",
-                "Writing - review & editing"
+                "Funding acquisition"
             ],
             "curated_relation": true,
             "emails": [
-                "JiOjS51OUadQvM5@kWjDmrcl.fdq",
-                "a4h7OUUE@Mwl.tej",
-                "uhJN35O@ysKXMnDFiGlubiBBufGCWmSSzc.volz"
+                "nYhqMh@gbJvdlQm.yi",
+                "fhcGMYY71FUul5@SANSIiZWxWrOLnjCtCBAZNT.lu",
+                "CP24gKH@sR.cpe",
+                "bBG-6j1OxDjD@NxlWnscoCcchHwOy.fgwj"
             ],
-            "full_name": "esse Lorem Duis deserunt nostrud",
+            "full_name": "ut sit",
             "ids": [
                 {
-                    "type": "INSPIRE BAI",
-                    "value": "cJuBx.Nr.zvA.m.XSQc2ehPo.N.9Gk_EPBeC6.88473870153"
+                    "type": "ORCID",
+                    "value": "6334-0039-3231-1726"
                 },
                 {
-                    "type": "INSPIRE BAI",
-                    "value": "U.YOYba5IP.FiQOlZo.KRA8EN.R.81xMYIxB.IKsO1yv6Ehi.E.2DhDnTa6WGR.OjHH.dp.2039011"
+                    "type": "ORCID",
+                    "value": "0628-0986-8519-4922"
                 },
                 {
-                    "type": "INSPIRE BAI",
-                    "value": "bgVgm.dvaS.4J2c.LI.sUabA1UvJ6.o5RktU.iZM.8P.J0D.9"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "JQfBzg7uo.ZX5L.qqsP.3n59imOs.y8d.LoUrLqC.yPQAow1Yrsv.H.G.uXfLHuDOIsA.uaK.62247"
+                    "type": "ORCID",
+                    "value": "7839-5974-7355-3543"
                 }
             ],
             "inspire_roles": [
+                "editor",
                 "author",
                 "supervisor"
             ],
             "raw_affiliations": [
                 {
-                    "source": "esse",
-                    "value": "sunt commodo"
+                    "source": "in",
+                    "value": "eiusmod exercitatio"
                 },
                 {
-                    "source": "irure incididunt",
-                    "value": "Ut laborum"
-                },
-                {
-                    "source": "nulla",
-                    "value": "mollit"
-                },
-                {
-                    "source": "dolor tempor mollit sunt velit",
-                    "value": "et labore proident anim elit"
-                },
-                {
-                    "source": "minim dolor sint eu in",
-                    "value": "eu aute ipsum"
+                    "source": "irure elit commodo",
+                    "value": "eiusmod elit"
                 }
             ],
             "record": {
-                "$ref": "http://1PBP"
+                "$ref": "http://1OCcvV"
             },
-            "uuid": "19e3db40-60be-f823-3ba9-af9511b8e677"
+            "uuid": "df792629-8f3b-2e26-7bf1-d8ad11401b76"
+        },
+        {
+            "affiliations": [
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://13n|"
+                    },
+                    "value": "Lorem ut cupidatat nostr"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1qxvW88U3Y}"
+                    },
+                    "value": "ad"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1}j"
+                    },
+                    "value": "incididunt voluptate "
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1Vu!]"
+                    },
+                    "value": "ex non"
+                }
+            ],
+            "alternative_names": [
+                "laboris officia aute",
+                "do",
+                "cillum mollit dolor sint voluptate"
+            ],
+            "credit_roles": [
+                "Validation"
+            ],
+            "curated_relation": false,
+            "emails": [
+                "BzEzImT9pZuZJvl@UdsXEjcP.qqma",
+                "V6xKLM-H@UFEvYXmdgWrscoAHediF.rix",
+                "w1bhXUWUCAVI@xKGVIdUhEORxeuzqqqQcKB.xlmg",
+                "qK4QoYD@frpxWyKfHo.popo"
+            ],
+            "full_name": "Excepteur id",
+            "ids": [
+                {
+                    "type": "ORCID",
+                    "value": "3213-1043-3884-4690"
+                },
+                {
+                    "type": "ORCID",
+                    "value": "6207-3304-0473-6350"
+                },
+                {
+                    "type": "ORCID",
+                    "value": "5453-3896-1187-6205"
+                },
+                {
+                    "type": "ORCID",
+                    "value": "5702-6418-6793-0929"
+                },
+                {
+                    "type": "ORCID",
+                    "value": "8077-7551-9697-4853"
+                }
+            ],
+            "inspire_roles": [
+                "author",
+                "author",
+                "editor"
+            ],
+            "raw_affiliations": [
+                {
+                    "source": "incididunt deserunt est",
+                    "value": "exercitation aliqua ut"
+                },
+                {
+                    "source": "nostrud nisi qui proident",
+                    "value": "consequat Ut Excepteur culpa"
+                },
+                {
+                    "source": "qui aliquip ut exercitation",
+                    "value": "id veniam"
+                }
+            ],
+            "record": {
+                "$ref": "http://1j/"
+            },
+            "uuid": "8b471665-e564-1df8-5dab-740792a66b71"
         },
         {
             "affiliations": [
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1%w*xC"
+                        "$ref": "http://1(<F^"
                     },
-                    "value": "adipisicing"
+                    "value": "irure eiusmod nulla dolor amet"
                 },
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1f"
+                        "$ref": "http://15F5t-6uj"
                     },
-                    "value": "voluptate Duis dolor amet sunt"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1&3>_0va\"Et"
-                    },
-                    "value": "cupidatat proident Ut ad reprehenderit"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1*;+NCO]O"
-                    },
-                    "value": "officia veniam"
+                    "value": "do"
                 }
             ],
             "alternative_names": [
-                "sed esse amet eu proident",
-                "ex ea aliquip tempor do",
-                "cillum do",
-                "laborum"
+                "in sunt et",
+                "esse magna ipsum ut pariatur",
+                "non in",
+                "amet elit ullamco aliquip",
+                "id"
             ],
             "credit_roles": [
-                "Project administration",
-                "Validation",
+                "Methodology",
+                "Funding acquisition",
                 "Methodology"
             ],
             "curated_relation": true,
             "emails": [
-                "19AEcuq@HpnaQeaOCjWfYegQiHYynzGH.rnjh",
-                "aAivCiKSxrm@YZfWAb.zc",
-                "qm5t3Aal-Xg@PYwNNTqYkruGjYtUnmYwgeDHjxBQNzP.fsd",
-                "anQfsmVrf3YUr@PXbTzzkFu.irn"
+                "GEQrGsZckYjjp0@MgACFIQuglSBpQkAXDSjj.zas",
+                "O9eYdhF2SW@rqwXvbNWy.rxzw",
+                "rZ6cDx@gBhrpQXbSIsIlJlAHBTJSIyZjJmqLFN.rpfo",
+                "y1N3qAnzk@exfcOIsYMmeXZQRfHKBzCaoisTPputQv.ze",
+                "H-AEPtQ@NwMZNKUvy.iym"
             ],
-            "full_name": "Lorem Excepteur eiusmod eu sunt",
+            "full_name": "Lorem dolor",
             "ids": [
                 {
-                    "type": "INSPIRE BAI",
-                    "value": "9yvWWjpU.2MWXccqO0HC.9Ay7XgdFArN.C.0PtHaol7db.6877610442"
+                    "type": "ORCID",
+                    "value": "5542-4340-6515-4652"
                 },
                 {
-                    "type": "INSPIRE BAI",
-                    "value": "3Js.NL_oPemc.BWAdejvpQn.p3.IJWF.ITdO.jBLKr62ck.a_2169pJv.756"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "id82U.GDXsmsAeHC.FP.Vv7WaGHp.jQ.tjspK.NEt.8G3WxDEI6k.I10hc.ezl9ff8.6833399"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "hWru.cNZZI.3169390"
+                    "type": "ORCID",
+                    "value": "5330-2363-9552-2648"
                 }
             ],
             "inspire_roles": [
-                "editor",
                 "supervisor",
                 "supervisor",
-                "editor",
-                "editor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "occaecat ex",
-                    "value": "officia minim deserunt"
-                },
-                {
-                    "source": "do commodo",
-                    "value": "cillum dolore amet cupidatat"
-                },
-                {
-                    "source": "labore",
-                    "value": "elit ullamco laborum non eu"
-                },
-                {
-                    "source": "Ut irure non dolore",
-                    "value": "nisi ullamco elit consectetur anim"
-                }
-            ],
-            "record": {
-                "$ref": "http://10-r3^EX"
-            },
-            "uuid": "53b68815-fd55-6d99-bf92-fe139bdaf9c1"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1QlB"
-                    },
-                    "value": "Ut sunt"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1"
-                    },
-                    "value": "et dolor velit"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1q0v"
-                    },
-                    "value": "ex sit non reprehenderit officia"
-                }
-            ],
-            "alternative_names": [
-                "minim adipisicing qui"
-            ],
-            "credit_roles": [
-                "Conceptualization",
-                "Supervision"
-            ],
-            "curated_relation": false,
-            "emails": [
-                "Srn05tAVnnPjd9@yHcmrbqAGOwJHTjhTiYERcVCvTcLQV.pjkj",
-                "P-px@tuhihsTbDnqVsmgMGvK.sg"
-            ],
-            "full_name": "a",
-            "ids": [
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "4hYqU.lB3PQ2.L4wbvo.Zaq3._.j6wELt.PBM5.eAhe.02609897"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "eepY.aZ.WhH6v0Y0.gc7aJCUw5Z.lp_rBskDWOV.7lruk.2055368935"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "4.zFtnM9POnJ.FCOUB80w.Yak.7"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "yX4l8.hwQNV0SR.28"
-                }
-            ],
-            "inspire_roles": [
-                "editor",
-                "editor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "eu in ad Ut laborum",
-                    "value": "in"
-                },
-                {
-                    "source": "aliqua ad incididunt",
-                    "value": "dolor officia non"
-                },
-                {
-                    "source": "eu cillum proident dolore",
-                    "value": "sed"
-                },
-                {
-                    "source": "deserunt eiusmod",
-                    "value": "enim exercitation ex"
-                }
-            ],
-            "record": {
-                "$ref": "http://1xR=C^9 M."
-            },
-            "uuid": "dfbff82a-9499-40cc-0446-d47c7991c511"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1+\\x3gQ"
-                    },
-                    "value": "in aliqua"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1<Tw"
-                    },
-                    "value": "sint reprehenderit "
-                }
-            ],
-            "alternative_names": [
-                "exercitation consectetur amet anim",
-                "anim",
-                "non",
-                "consectetur commodo"
-            ],
-            "credit_roles": [
-                "Funding acquisition",
-                "Resources"
-            ],
-            "curated_relation": true,
-            "emails": [
-                "y5uZs3g@MPBfazwhQWqubHdQ.zqoi",
-                "DKw6m3NymOhWl3f@luSrgiTCKRCcWVqjnImL.xkoe",
-                "fKT7fgn@gGRxSCDhJlZaBlcVq.awri",
-                "ApLJ@nQTVisdoJcCRrkHo.fcl",
-                "Qiwjsg4Dos@rcUJyVuERrNQyKrTmhPuXnfr.qi"
-            ],
-            "full_name": "ut quis commodo",
-            "ids": [
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "oHLLvx.e.ZpB3Z6fC.zH2Lqw9.LF0Ao_VT9zP.054120270"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "lRYdv5w.iK7._gZx.fCEOB.AqEc1yY4__.H0DImJ3sVH7.760521"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "CAj.3rU9Mr.tYAd99No4X.HgTPJpop.2365496"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "ALD6gM.OyZbL0Y1.5rpf_1Ngsw9.pW.sx8.6o.ntw3JINYPG_.QsM.Khg0AQ_dF.0.98697"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "dTpTjK5.r.NN.RvteEPj89.32"
-                }
-            ],
-            "inspire_roles": [
-                "editor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "et officia exercitation ad ",
-                    "value": "laborum dolore mollit culpa"
-                },
-                {
-                    "source": "voluptate adipisicing",
-                    "value": "laborum ullamco non"
-                }
-            ],
-            "record": {
-                "$ref": "http://1|#05eZG^#`"
-            },
-            "uuid": "93ab58d7-1c4d-0929-5f53-fcdebd992aed"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1'L0H;k~"
-                    },
-                    "value": "nulla minim pariatur tempor esse"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1"
-                    },
-                    "value": "ea Duis eu"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1pl=Z=^z"
-                    },
-                    "value": "incididunt laboris ut eu"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1i@jP"
-                    },
-                    "value": "aliqua elit dolor non pariatur"
-                }
-            ],
-            "alternative_names": [
-                "qui est",
-                "cillum pariatur culpa et id"
-            ],
-            "credit_roles": [
-                "Software",
-                "Project administration",
-                "Formal analysis",
-                "Formal analysis"
-            ],
-            "curated_relation": false,
-            "emails": [
-                "YJN@nKZBvwpjOLuVWYMq.ifmx",
-                "CZcAB0x@XWiCdSDe.xsx"
-            ],
-            "full_name": "Excepteur Ut",
-            "ids": [
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "2owiw0H5Ir5.fs6iwlxOw9.FxuPqEror5N.JYlp_.53"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "tF1.FprukKUs2jO.Q.q.wr.MJT6P.uf2kz.0.a.740157714"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "k.GUX8aclWY.Yw.6fWXWX.QVVbB.wBINWjIry7.W.858"
-                },
-                {
-                    "type": "INSPIRE BAI",
-                    "value": "rU.Up1On6lHPF.LZP_6RCe.4"
-                }
-            ],
-            "inspire_roles": [
-                "editor",
+                "author",
+                "supervisor",
                 "supervisor"
             ],
             "raw_affiliations": [
                 {
-                    "source": "exercitation ullamco",
-                    "value": "amet"
+                    "source": "ea officia anim laboris",
+                    "value": "tempor officia labore ut"
                 },
                 {
-                    "source": "elit ex",
-                    "value": "est consectetur"
-                },
-                {
-                    "source": "cillum quis Duis voluptate Lorem",
-                    "value": "est minim"
-                },
-                {
-                    "source": "anim adipisicing in est Ut",
-                    "value": "velit officia"
-                },
-                {
-                    "source": "et sed",
-                    "value": ""
+                    "source": "dolore qui",
+                    "value": "u"
                 }
             ],
             "record": {
-                "$ref": "http://1SLE&+g-B@V"
+                "$ref": "http://1"
             },
-            "uuid": "b4ce6d24-a97d-c7cb-eeba-6942de2a0620"
+            "uuid": "5abcce98-1462-bb52-4d18-806e5885e96d"
         }
     ],
     "book_series": [
         {
-            "title": "nulla Lorem elit",
-            "volume": "dolor incididunt"
+            "title": "adipisicing exercitation esse",
+            "volume": "adipisicing Lorem magna anim voluptate"
         },
         {
-            "title": "cupidatat commodo et qui esse",
-            "volume": "veniam dolore laboris est Excepteur"
+            "title": "occaecat in",
+            "volume": "ad reprehenderit velit"
         },
         {
-            "title": "ullamco voluptate",
-            "volume": "mollit proident ea"
+            "title": "dolor esse in",
+            "volume": "veniam ut commodo"
         },
         {
-            "title": "quis ani",
-            "volume": "esse"
+            "title": "deserunt sed pariatur",
+            "volume": "in nostrud Excepteur"
         },
         {
-            "title": "non in pariatur exercitation ad",
-            "volume": "nulla eiusmod consequat elit"
+            "title": "in",
+            "volume": "dolore Lorem sunt qui"
         }
     ],
     "citeable": false,
     "collaborations": [
         {
             "record": {
-                "$ref": "http://11$"
+                "$ref": "http://1\"XJ>h"
             },
-            "value": "exercitation cupidatat enim reprehenderit dolore"
+            "value": "Ut eni"
         },
         {
             "record": {
-                "$ref": "http://1>;~<"
+                "$ref": "http://15q\\oxl;\\"
             },
-            "value": "commodo exercitation labore ad"
+            "value": "reprehenderit magna elit velit in"
         },
         {
             "record": {
-                "$ref": "http://1[ i7"
+                "$ref": "http://1Oz"
             },
-            "value": "incididunt"
-        },
-        {
-            "record": {
-                "$ref": "http://1uT"
-            },
-            "value": "est in eiusmod"
+            "value": "et"
         }
     ],
-    "control_number": -19070658,
+    "control_number": -41598789,
     "copyright": [
         {
-            "holder": "",
+            "holder": "non qui reprehenderit pariatur",
             "material": "erratum",
-            "statement": "cupidatat deserunt",
-            "url": "http://1})fFc2uA"
+            "statement": "nostrud",
+            "url": "http://1K*!1ltmi"
+        },
+        {
+            "holder": "nisi veniam",
+            "material": "reprint",
+            "statement": "eu Lorem ex",
+            "url": "http://1slB(%"
+        },
+        {
+            "holder": "officia voluptate adipisi",
+            "material": "erratum",
+            "statement": "dolore esse laboris ea aute",
+            "url": "http://1thRq&3"
         }
     ],
     "core": false,
     "corporate_author": [
-        "amet esse reprehenderit",
-        "reprehenderit",
-        "dolore proident sint occaecat fugiat"
+        "ea ex anim commodo sunt",
+        "occaecat et do labore ",
+        "sint consequat nul",
+        "laborum consequat proid"
     ],
     "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://1qZ9!i-"
+            "$ref": "http://17wRA"
         },
         {
-            "$ref": "http://1,zWe"
+            "$ref": "http://1h"
+        },
+        {
+            "$ref": "http://1&s,kDJ);*A"
+        },
+        {
+            "$ref": "http://1"
         }
     ],
     "document_type": [
-        "book chapter",
-        "article",
-        "report",
-        "thesis"
+        "proceedings",
+        "thesis",
+        "book",
+        "article"
     ],
     "dois": [
         {
-            "material": "reprint",
-            "source": "proident in",
-            "value": "10.7/p]j\\_;>r"
-        },
-        {
-            "material": "addendum",
-            "source": "dolor in esse",
-            "value": "10.8598/JR{}#3C"
-        },
-        {
-            "material": "addendum",
-            "source": "nostrud",
-            "value": "10.98298950.133821480/12BBO"
-        },
-        {
-            "material": "reprint",
-            "source": "in",
-            "value": "10.2220.4430/BAQte\\ ^\\Tp"
-        },
-        {
             "material": "publication",
-            "source": "nostrud laboris ut laborum id",
-            "value": "10.61.1965213/'xH}GY"
+            "source": "culpa proident",
+            "value": "10.7119355/K0{++}VCq"
+        },
+        {
+            "material": "erratum",
+            "source": "Duis",
+            "value": "10.8536.799/<,R}|g}+Zzp"
         }
     ],
     "edition": [
         {
-            "edition": "consequat id pariatur sunt laboris"
+            "edition": "non Lorem"
+        },
+        {
+            "edition": "tempor Lorem consequat"
+        },
+        {
+            "edition": "nulla voluptate Lorem"
+        },
+        {
+            "edition": "eiusmod cupidatat dolor"
         }
     ],
     "energy_ranges": [
-        11888275,
-        66036164,
-        67114658,
-        77905726
+        9225988,
+        59593396,
+        8945671
     ],
     "external_system_identifiers": [
         {
-            "schema": "qui Ut cillum",
-            "value": "dolor ex"
+            "schema": "irure",
+            "value": "eiusmod ipsum aliqua"
+        },
+        {
+            "schema": "non quis",
+            "value": "deserunt dolore"
+        },
+        {
+            "schema": "qui nisi Duis magna",
+            "value": "enim esse qui"
+        },
+        {
+            "schema": "quis moll",
+            "value": "Excepteur sint"
         }
     ],
     "funding_info": [
         {
-            "agency": "eu minim",
-            "grant_number": "amet ex",
-            "project_number": "i"
+            "agency": "consectetur do sit ex nisi",
+            "grant_number": "dolor aliquip dolore proident laborum",
+            "project_number": "elit"
         },
         {
-            "agency": "esse amet in in cillum",
-            "grant_number": "eiusmod sed",
-            "project_number": "irure"
+            "agency": "commodo veniam eu esse occaecat",
+            "grant_number": "est",
+            "project_number": "reprehenderit magna laboris eu"
         },
         {
-            "agency": "sint in proident amet quis",
-            "grant_number": "aliquip",
-            "project_number": "officia"
+            "agency": "proident ea occaecat",
+            "grant_number": "culpa commodo in aliquip",
+            "project_number": "tempor"
         },
         {
-            "agency": "id tempor ex consectetur officia",
-            "grant_number": "irure nostrud ipsum",
-            "project_number": "Duis in enim"
+            "agency": "et magna do",
+            "grant_number": "in minim in Ut",
+            "project_number": "in eiusmod esse"
+        },
+        {
+            "agency": "Ut cupidatat est commodo",
+            "grant_number": "dolore culpa dolor velit eiusmod",
+            "project_number": "voluptate elit veli"
         }
     ],
     "imprints": [
         {
             "date": "dddd-dd-dd",
-            "place": "in elit",
-            "publisher": "cillum in"
+            "place": "Ut",
+            "publisher": "sit dolor"
         },
         {
             "date": "dddd-dd-dd",
-            "place": "officia deserunt in labore",
-            "publisher": "sint Lorem aute veniam"
+            "place": "eu sint",
+            "publisher": "reprehenderit"
         },
         {
             "date": "dddd-dd-dd",
-            "place": "ut veniam laboris",
-            "publisher": "nostrud ut ea"
+            "place": "qui reprehenderit in",
+            "publisher": "qui eu dolor do"
+        },
+        {
+            "date": "dddd-dd-dd",
+            "place": "dolore magna",
+            "publisher": "sunt Ut aliqua Lorem"
         }
     ],
     "inspire_categories": [
         {
-            "source": "arxiv",
-            "term": "Instrumentation"
+            "source": "magpie",
+            "term": "Data Analysis and Statistics"
+        },
+        {
+            "source": "undefined",
+            "term": "Lattice"
+        },
+        {
+            "source": "magpie",
+            "term": "Math and Math Physics"
         },
         {
             "source": "user",
-            "term": "Other"
-        },
-        {
-            "source": "curator",
-            "term": "Accelerators"
-        },
-        {
-            "source": "curator",
-            "term": "Instrumentation"
-        },
-        {
-            "source": "curator",
-            "term": "Experiment-Nucl"
+            "term": "Math and Math Physics"
         }
     ],
     "isbns": [
         {
-            "medium": "print",
-            "value": "2"
+            "medium": "hardcover",
+            "value": "32878745"
         },
         {
             "medium": "hardcover",
-            "value": "7628871"
+            "value": "1X"
+        },
+        {
+            "medium": "softcover",
+            "value": "81"
+        },
+        {
+            "medium": "softcover",
+            "value": "9504X"
         },
         {
             "medium": "online",
-            "value": "1474801741"
-        },
-        {
-            "medium": "print",
-            "value": "160X"
+            "value": "424112913"
         }
     ],
     "keywords": [
         {
-            "schema": "PACS",
-            "source": "reprehenderit Lorem dolor",
-            "value": "ut proident commodo aliqua enim"
+            "schema": "INSPIRE",
+            "source": "officia do aute",
+            "value": "laboris"
+        },
+        {
+            "schema": "JACOW",
+            "source": "amet fugiat officia et",
+            "value": "magna culpa occaecat"
         },
         {
             "schema": "PACS",
-            "source": "ea esse",
-            "value": "culpa"
+            "source": "consectetu",
+            "value": "dolore ad cillum exercitation"
         },
         {
-            "schema": "PACS",
-            "source": "non irure ullamco dolor null",
-            "value": "nulla nostrud"
+            "schema": "JACOW",
+            "source": "consequat tempor quis",
+            "value": "officia pariatur quis irure elit"
+        },
+        {
+            "schema": "INSPIRE",
+            "source": "magna",
+            "value": "ad"
         }
     ],
     "languages": [
-        "GI",
-        "vN",
-        "6v",
-        "ay",
-        "Z3"
+        "SU",
+        "SP",
+        "ka"
     ],
+    "legacy_creation_date": "4529-03-22T18:48:06.537Z",
     "license": [
         {
-            "imposing": "sed dolore laborum ut",
+            "imposing": "ad",
+            "license": "enim amet qui aute",
+            "material": "addendum",
+            "url": "http://1Tk9n"
+        },
+        {
+            "imposing": "aliqua cupidatat fugiat occaecat id",
+            "license": "E",
+            "material": "addendum",
+            "url": "http://1Pq"
+        },
+        {
+            "imposing": "dolore",
             "license": "ea",
-            "material": "addendum",
-            "url": "http://1("
+            "material": "reprint",
+            "url": "http://1/tXN+0Y@UP"
         },
         {
-            "imposing": "cillum nulla amet sed",
-            "license": "sint incididunt",
-            "material": "preprint",
-            "url": "http://1OEa<X4ML"
-        },
-        {
-            "imposing": "c",
-            "license": "elit eiusmod cupidatat laboris laborum",
-            "material": "addendum",
-            "url": "http://1B"
-        },
-        {
-            "imposing": "tempor et do",
-            "license": "incididunt amet sed",
-            "material": "addendum",
-            "url": "http://1&?"
-        },
-        {
-            "imposing": "aliqua dolor laboris",
-            "license": "Ut cupidatat minim",
-            "material": "addendum",
-            "url": "http://1QupO"
+            "imposing": "veniam in fugiat dolore",
+            "license": "ut veniam exercitation occaecat",
+            "material": "erratum",
+            "url": "http://1ZF\\FH:h)"
         }
     ],
     "new_record": {
-        "$ref": "http://1a{H,"
+        "$ref": "http://1('"
     },
-    "number_of_pages": 73051610,
+    "number_of_pages": 68301232,
     "persistent_identifiers": [
         {
-            "material": "erratum",
+            "material": "preprint",
             "schema": "HDL",
-            "source": "sed amet sint dolore consectetur",
-            "value": "aliquip dolore "
-        },
-        {
-            "material": "erratum",
-            "schema": "URN",
-            "source": "incididunt ad elit",
-            "value": "dolore elit Excepteur ipsum"
+            "source": "ad eu dolor consequat et",
+            "value": "est in exercitation"
         }
     ],
     "preprint_date": "dddd-dd-dd",
     "public_notes": [
         {
-            "source": "ut eiusmod dolore Duis e",
-            "value": "dolor irure"
+            "source": "veniam adipisicing cupidatat enim velit",
+            "value": "reprehenderit ex do dolor voluptate"
         },
         {
-            "source": "do",
-            "value": "pariatur dolor aliquip in eiusm"
+            "source": "ipsum officia tem",
+            "value": "esse voluptate"
         },
         {
-            "source": "elit nulla",
-            "value": "quis"
-        },
-        {
-            "source": "aute Excepteur laborum labore anim",
-            "value": "laboris magna dolor fugiat dolore"
-        },
-        {
-            "source": "commodo eiusmod occaecat aliqua dolore",
-            "value": "officia do ea cupidatat sint"
+            "source": "ut eiusmod pariatur sunt occaecat",
+            "value": "deserunt"
         }
     ],
     "publication_info": [
         {
-            "artid": "laboris in sed Lorem proiden",
-            "cnum": "C29-44-57",
-            "conf_acronym": "consequat adipisicing sed dolor",
-            "conference_record": {
-                "$ref": "http://1G9U%"
-            },
-            "confpaper_info": "ipsum adipisicing eu id in",
-            "curated_relation": true,
-            "journal_issue": "eiusmod i",
-            "journal_record": {
-                "$ref": "http://1259v>}5"
-            },
-            "journal_title": "labore id proident pariatur cillum",
-            "journal_volume": "consectetur velit",
-            "material": "reprint",
-            "page_end": "e",
-            "page_start": "nisi",
-            "parent_isbn": "319507169X",
-            "parent_record": {
-                "$ref": "http://1mP"
-            },
-            "parent_report_number": "mollit ea veniam irure",
-            "pubinfo_freetext": "officia proident qui",
-            "year": 1844
-        },
-        {
-            "artid": "ut dolore commodo deserunt",
-            "cnum": "C49-55-43.68327",
-            "conf_acronym": "sed",
+            "artid": "exercitation culpa",
+            "cnum": "C89-48-70.1644",
+            "conf_acronym": "non id",
             "conference_record": {
                 "$ref": "http://1"
             },
-            "confpaper_info": "reprehenderit anim deserunt dolor",
+            "confpaper_info": "sed reprehenderit",
             "curated_relation": false,
-            "journal_issue": "",
+            "journal_issue": "culpa anim Ut aute",
             "journal_record": {
-                "$ref": "http://1:Tb>}]j9"
+                "$ref": "http://1"
             },
-            "journal_title": "ea nostrud consequat",
-            "journal_volume": "eiusmod officia esse",
-            "material": "preprint",
-            "page_end": "anim incidi",
-            "page_start": "nisi laborum velit culpa officia",
-            "parent_isbn": "9785553089637",
-            "parent_record": {
-                "$ref": "http://1Cuocm"
-            },
-            "parent_report_number": "nostrud aliquip veniam nisi",
-            "pubinfo_freetext": "do voluptate",
-            "year": 1392
-        },
-        {
-            "artid": "exercitation sint anim enim ullamco",
-            "cnum": "C53-17-11",
-            "conf_acronym": "ad laborum est nostrud aute",
-            "conference_record": {
-                "$ref": "http://1TjFyQ"
-            },
-            "confpaper_info": "eiusmod pariatur nulla dol",
-            "curated_relation": true,
-            "journal_issue": "exercitation laborum irure pariatur",
-            "journal_record": {
-                "$ref": "http://1iK`(:iB0>"
-            },
-            "journal_title": "nulla deserunt pariatur cupidat",
-            "journal_volume": "laborum cillum pariatur",
-            "material": "addendum",
-            "page_end": "culpa Lorem ut quis",
-            "page_start": "dolore",
-            "parent_isbn": "535139837X",
-            "parent_record": {
-                "$ref": "http://1zzTj&NE"
-            },
-            "parent_report_number": "amet quis sint nulla magna",
-            "pubinfo_freetext": "ipsum consequat pariatur ullamco magna",
-            "year": 1595
-        },
-        {
-            "artid": "occaecat et dolor",
-            "cnum": "C31-74-03",
-            "conf_acronym": "fugiat",
-            "conference_record": {
-                "$ref": "http://1%;pe"
-            },
-            "confpaper_info": "Ut",
-            "curated_relation": false,
-            "journal_issue": "Lorem quis",
-            "journal_record": {
-                "$ref": "http://1~kU&x_CXj"
-            },
-            "journal_title": "sint minim anim",
-            "journal_volume": "veniam aute ad reprehenderit",
-            "material": "addendum",
-            "page_end": "voluptate",
-            "page_start": "irure",
-            "parent_isbn": "979425791135X",
+            "journal_title": "reprehenderit sed do",
+            "journal_volume": "ex ea occaecat Excepteur laborum",
+            "material": "erratum",
+            "page_end": "ullamco et",
+            "page_start": "dolor in in elit exercitation",
+            "parent_isbn": "489479294X",
             "parent_record": {
                 "$ref": "http://1"
             },
-            "parent_report_number": "sed sit",
-            "pubinfo_freetext": "fugiat pariatur eu commodo quis",
-            "year": 1985
-        },
-        {
-            "artid": "dolore qui sit",
-            "cnum": "C43-63-54.208209",
-            "conf_acronym": "amet ex esse",
-            "conference_record": {
-                "$ref": "http://1{7"
-            },
-            "confpaper_info": "aliquip do Duis adipisicing tempor",
-            "curated_relation": false,
-            "journal_issue": "tempor",
-            "journal_record": {
-                "$ref": "http://1;'R>Wi+j%N"
-            },
-            "journal_title": "magna non fugiat Ut",
-            "journal_volume": "ut Lorem",
-            "material": "preprint",
-            "page_end": "tempor do sint cillum in",
-            "page_start": "adipisicing pariatur proident irure deserunt",
-            "parent_isbn": "979580149753X",
-            "parent_record": {
-                "$ref": "http://1GW|aef` "
-            },
-            "parent_report_number": "dolore in non",
-            "pubinfo_freetext": "quis dolor",
-            "year": 1015
+            "parent_report_number": "sed",
+            "pubinfo_freetext": "minim culpa",
+            "year": 1095
         }
     ],
     "publication_type": [
-        "introductory",
         "review",
-        "lectures",
+        "introductory",
+        "introductory",
         "introductory"
     ],
-    "refereed": true,
+    "refereed": false,
     "references": [
         {
             "curated_relation": false,
             "raw_refs": [
                 {
-                    "position": "laboris",
-                    "schema": "o",
-                    "source": "in velit ut sed volup",
-                    "value": "aliqua id veniam"
+                    "position": "cupidatat",
+                    "schema": "sunt",
+                    "source": "adipisicing dolor aliqua",
+                    "value": "exercitation aute proident reprehenderit sunt"
                 },
                 {
-                    "position": "Ut sunt cupidatat ullamco amet",
-                    "schema": "nisi ",
-                    "source": "cupidatat non",
-                    "value": "ven"
+                    "position": "anim mollit cupidatat est",
+                    "schema": "est ea dolore deserunt",
+                    "source": "nostrud fugiat",
+                    "value": "cupidatat"
                 },
                 {
-                    "position": "culpa nostrud in",
-                    "schema": "deserunt sed incididunt dolor laborum",
-                    "source": "aliqua ut",
-                    "value": "aliquip"
-                },
-                {
-                    "position": "velit qui in fugiat",
-                    "schema": "eu qui do aliquip ut",
-                    "source": "Lorem",
-                    "value": "nostrud est incididunt consequat in"
-                },
-                {
-                    "position": "proident dolor",
-                    "schema": "qui commodo Excepteur",
-                    "source": "veniam adipisicing ",
-                    "value": "cupidatat incididunt culpa nostrud"
+                    "position": "in laboris qui commodo",
+                    "schema": "exercitation non deserunt voluptate",
+                    "source": "laboris eiusmod ea aute",
+                    "value": "labore elit sit"
                 }
             ],
             "record": {
-                "$ref": "http://1kg"
+                "$ref": "http://1v<"
             },
             "reference": {
                 "arxiv_eprints": [
-                    "if/319",
-                    "4078]5766",
-                    "6337'21755",
-                    "PNw6uNOZp_-9/5207",
-                    "kN8P50pU-benY/59246478"
+                    "1242C8324",
+                    "AkBTlLV6pQm/72364",
+                    "bZfAbwX/31",
+                    "j3F_-Ecp/1769347677"
                 ],
                 "authors": [
                     {
-                        "full_name": "dolor cillum",
-                        "role": "pariatur laborum in"
+                        "full_name": "aliqua",
+                        "role": "adipisicing et velit in"
                     },
                     {
-                        "full_name": "cupidatat",
-                        "role": "do pariatur qui exercitation ut"
-                    },
-                    {
-                        "full_name": "ut",
-                        "role": "do quis"
-                    },
-                    {
-                        "full_name": "officia sunt laborum velit",
-                        "role": "aliqua"
-                    },
-                    {
-                        "full_name": "laboris",
-                        "role": "mollit et magna Ex"
+                        "full_name": "voluptate",
+                        "role": "deserunt est commodo labo"
                     }
                 ],
                 "book_series": {
-                    "title": "est in fugiat",
-                    "volume": "occaecat consectetur mollit fugiat est"
+                    "title": "veniam",
+                    "volume": "Excepteur est Ut"
                 },
                 "collaboration": [
-                    "in ipsum",
-                    "sint ad consectet",
-                    "mollit sed esse dolor ut",
-                    "aliquip reprehenderit",
-                    "cupidatat mollit"
+                    "incididunt consequat ullamco"
                 ],
                 "dois": [
-                    "10.2725098.480/M!KTL6iRd",
-                    "10.1.2947/|V9"
+                    "10.685.690866746/E>-",
+                    "10.4/uAS",
+                    "10.5216384731/&^:ZL\"tez}a"
                 ],
                 "imprint": {
                     "date": "dddd-dd-dd",
-                    "place": "non enim ea sit",
-                    "publisher": ""
+                    "place": "nisi laboris incididunt dolor enim",
+                    "publisher": "in velit"
                 },
                 "misc": [
-                    "quis aliquip sed labore mollit",
-                    "pariatur ea proident",
-                    "proident dolor",
-                    "nulla"
+                    "aliqua",
+                    "magna adipisicing sint",
+                    "cupidatat sed",
+                    "qui nostrud reprehenderit"
                 ],
-                "number": -39767319,
+                "number": -31149055,
                 "persistent_identifiers": [
-                    "consequat",
-                    "adipisicing officia nostrud nulla dolore"
+                    "esse pariatur Excepteur laboris",
+                    "laboris",
+                    "anim eu quis do",
+                    "laborum au"
                 ],
                 "publication_info": {
-                    "artid": "labore sit ea eu anim",
-                    "cnum": "in culpa aliquip",
-                    "isbn": "exercitation sed",
-                    "journal_issue": "officia ut",
-                    "journal_title": "amet aliquip irure anim",
-                    "journal_volume": "non in nisi nostrud magna",
-                    "page_end": "nisi consectetur",
-                    "page_start": "amet aute Excepteur",
-                    "reportnumber": "dolore Ut nisi",
-                    "year": 1724
+                    "artid": "minim ea culpa Duis",
+                    "cnum": "enim dolor",
+                    "isbn": "in ut do adipisicing",
+                    "journal_issue": "dolor quis u",
+                    "journal_title": "nostrud dolore tempor in sint",
+                    "journal_volume": "dolore ut in sit",
+                    "page_end": "qui",
+                    "page_start": "sit amet est",
+                    "reportnumber": "ipsum",
+                    "year": 1302
                 },
-                "texkey": "Excepteur",
+                "texkey": "exercitation aliquip",
                 "titles": [
                     {
-                        "source": "velit Ut",
-                        "subtitle": "nulla consequat enim amet eiusmod",
-                        "title": "occaecat"
-                    },
-                    {
-                        "source": "laboris",
-                        "subtitle": "Excepteur labore laboris",
-                        "title": "nostrud magna"
-                    },
-                    {
-                        "source": "qui dolore",
-                        "subtitle": "consequat dolor irure",
-                        "title": "al"
+                        "source": "officia",
+                        "subtitle": "aute",
+                        "title": "ad eiusmod"
                     }
                 ],
                 "urls": [
                     {
-                        "description": "ea veniam occaecat adipisicing",
-                        "value": "http://1FNLz"
-                    },
-                    {
-                        "description": "Ut dolor laborum",
-                        "value": "http://1YS__"
-                    },
-                    {
-                        "description": "enim",
-                        "value": "http://18,"
-                    },
-                    {
-                        "description": "sit in do",
-                        "value": "http://1|J*| "
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": false,
-            "raw_refs": [
-                {
-                    "position": "aute",
-                    "schema": "repre",
-                    "source": "dolore culpa id mollit",
-                    "value": "ullamco in magna rep"
-                },
-                {
-                    "position": "cupidatat deserunt id sed",
-                    "schema": "",
-                    "source": "culpa ullamco eu",
-                    "value": "nostrud in re"
-                },
-                {
-                    "position": "nulla ad",
-                    "schema": "aliquip fugiat ex anim reprehenderit",
-                    "source": "ipsum consectetur ex amet",
-                    "value": "nisi ipsum ut deserunt mollit"
-                }
-            ],
-            "record": {
-                "$ref": "http://1 "
-            },
-            "reference": {
-                "arxiv_eprints": [
-                    "BF-bcx5r_R/51510202912",
-                    "7uMh43mO-I3yiMOPv9ev/8830792994",
-                    "dRm-PdA5zZgG/312388",
-                    "l0qM/492"
-                ],
-                "authors": [
-                    {
-                        "full_name": "ea aliqua",
-                        "role": "proident qui dolor"
-                    },
-                    {
-                        "full_name": "eu",
-                        "role": "irure laboris minim in Ex"
-                    },
-                    {
-                        "full_name": "id do culpa dolore proident",
-                        "role": "ipsum"
-                    }
-                ],
-                "book_series": {
-                    "title": "minim deserunt",
-                    "volume": "aute"
-                },
-                "collaboration": [
-                    "Duis enim labore ipsum esse"
-                ],
-                "dois": [
-                    "10.43551/Afl#x,",
-                    "10.467/WqV,eIsHr/"
-                ],
-                "imprint": {
-                    "date": "dddd-dd-dd",
-                    "place": "ut ipsum sunt exercitation Duis",
-                    "publisher": "laborum co"
-                },
-                "misc": [
-                    "aliquip nulla",
-                    "irure",
-                    "nostrud consequat officia minim Ut",
-                    "fugiat",
-                    "do est"
-                ],
-                "number": 76841198,
-                "persistent_identifiers": [
-                    "sed",
-                    "non Lorem laborum consectetur culpa"
-                ],
-                "publication_info": {
-                    "artid": "velit ipsum proident",
-                    "cnum": "sint nulla",
-                    "isbn": "c",
-                    "journal_issue": "sunt incididunt adipisicing tempor",
-                    "journal_title": "fugiat",
-                    "journal_volume": "magna enim",
-                    "page_end": "commodo irure nulla ex",
-                    "page_start": "irure veli",
-                    "reportnumber": "ut do amet",
-                    "year": 1399
-                },
-                "texkey": "aliquip officia ex pariatur",
-                "titles": [
-                    {
-                        "source": "ut cillum sit commodo proident",
-                        "subtitle": "dolor Ut",
-                        "title": "non dolore"
-                    },
-                    {
-                        "source": "dolor reprehenderit nulla",
-                        "subtitle": "in",
-                        "title": "tempor cillum pariatur mollit ipsum"
-                    },
-                    {
-                        "source": "consequat ut in",
-                        "subtitle": "officia",
-                        "title": "et dolor est eu adipisicing"
-                    },
-                    {
-                        "source": "eiusmod Excepteur commodo cupidatat sed",
-                        "subtitle": "amet pariatur consectetur in",
-                        "title": "ipsum ullamco consequat id dolor"
-                    },
-                    {
-                        "source": "consectetur sit exercitation adipi",
-                        "subtitle": "incididunt",
-                        "title": "dolore veniam"
-                    }
-                ],
-                "urls": [
-                    {
-                        "description": "amet ",
-                        "value": "http://1>KOZ#"
-                    },
-                    {
-                        "description": "labore",
-                        "value": "http://1C f"
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": true,
-            "raw_refs": [
-                {
-                    "position": "dolor",
-                    "schema": "laboris",
-                    "source": "eu",
-                    "value": "irure deserunt"
-                },
-                {
-                    "position": "ipsum exercitation est",
-                    "schema": "proident dolore ullamco",
-                    "source": "in sint",
-                    "value": "veniam velit amet Duis adipisicing"
-                },
-                {
-                    "position": "et eu dolore",
-                    "schema": "id mollit officia",
-                    "source": "commodo sed ea deserunt",
-                    "value": "exercitation incididunt sunt"
-                },
-                {
-                    "position": "aliquip dolore do",
-                    "schema": "proident aliqua deserunt",
-                    "source": "Ut laboris",
-                    "value": "occaecat in"
-                }
-            ],
-            "record": {
-                "$ref": "http://1H,g0"
-            },
-            "reference": {
-                "arxiv_eprints": [
-                    "RX5lZ1Cj-mG8Hrz5B/33002356527"
-                ],
-                "authors": [
-                    {
-                        "full_name": "et ipsum occaecat enim",
-                        "role": "ea eu nulla magna"
-                    },
-                    {
-                        "full_name": "exercita",
-                        "role": "laboris commodo labore dolore eiusmod"
-                    },
-                    {
-                        "full_name": "reprehenderit elit esse commodo",
-                        "role": "nisi ad fugiat esse"
-                    },
-                    {
-                        "full_name": "officia enim",
-                        "role": "occaecat labore proident"
-                    },
-                    {
-                        "full_name": "ad cupidatat reprehenderit ipsum tempor",
-                        "role": "voluptate amet eiu"
-                    }
-                ],
-                "book_series": {
-                    "title": "ea in officia consectetur",
-                    "volume": "laboris eiusmod"
-                },
-                "collaboration": [
-                    "incididunt tempor nostrud"
-                ],
-                "dois": [
-                    "10.3521241529/E4Zb_pE,",
-                    "10.873697608.8939662/_!O"
-                ],
-                "imprint": {
-                    "date": "dddd-dd-dd",
-                    "place": "Duis consequat",
-                    "publisher": "exercitation ex eu"
-                },
-                "misc": [
-                    "labore aute ipsum et occaecat",
-                    "Excepteur pariatur sunt",
-                    "ut incididunt cupidatat Excepteur",
-                    "eiusmod in labore",
-                    "amet"
-                ],
-                "number": 5765354,
-                "persistent_identifiers": [
-                    "sint qui cupidatat",
-                    "velit laboris deserunt",
-                    "laboris culpa anim eu veniam"
-                ],
-                "publication_info": {
-                    "artid": "ea non irure culpa Excepteur",
-                    "cnum": "eu",
-                    "isbn": "minim ullamco cillum Lorem dolore",
-                    "journal_issue": "pariatur et nulla",
-                    "journal_title": "do et fugiat elit id",
-                    "journal_volume": "nulla in",
-                    "page_end": "non consectetur",
-                    "page_start": "reprehenderit ex dolor ipsum sunt",
-                    "reportnumber": "aliqua",
-                    "year": 1494
-                },
-                "texkey": "culpa laboris velit id commodo",
-                "titles": [
-                    {
-                        "source": "occaecat Ut fugiat ipsum in",
-                        "subtitle": "commodo",
-                        "title": "reprehenderit commodo elit consectetur en"
-                    },
-                    {
-                        "source": "consequat sint id dolore",
-                        "subtitle": "consequat dolore id laborum",
-                        "title": "cillum"
-                    },
-                    {
-                        "source": "dolor eiusmod laboris qui",
-                        "subtitle": "officia in",
-                        "title": "ex id non irure ip"
-                    },
-                    {
-                        "source": "occaecat",
-                        "subtitle": "voluptate qui est",
-                        "title": "est veniam ut elit reprehenderit"
-                    },
-                    {
-                        "source": "quis ad mollit consectetur cillum",
-                        "subtitle": "in tempor",
-                        "title": "veniam quis"
-                    }
-                ],
-                "urls": [
-                    {
-                        "description": "anim adipisicing Ut irure",
-                        "value": "http://1_xo"
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": true,
-            "raw_refs": [
-                {
-                    "position": "id pariatur et",
-                    "schema": "incididunt aliquip",
-                    "source": "officia",
-                    "value": "anim"
-                },
-                {
-                    "position": "qui mollit ",
-                    "schema": "nisi veniam ad ",
-                    "source": "et ut",
-                    "value": "occaecat enim proident"
-                },
-                {
-                    "position": "exercitation non fu",
-                    "schema": "Excepteur et aliqua non",
-                    "source": "amet ex laboris f",
-                    "value": "dolor sunt ex"
-                }
-            ],
-            "record": {
-                "$ref": "http://1&xaiDx$nv"
-            },
-            "reference": {
-                "arxiv_eprints": [
-                    "m28Kf-ULadv_sn/1487555",
-                    "iBhTWOi9SHn/797",
-                    "4425c8531"
-                ],
-                "authors": [
-                    {
-                        "full_name": "eu",
-                        "role": "in"
-                    },
-                    {
-                        "full_name": "eu do ipsum Excepteur elit",
-                        "role": "enim ex"
-                    },
-                    {
-                        "full_name": "quis",
-                        "role": "cupidatat consectetur aliquip"
-                    },
-                    {
-                        "full_name": "qui proident pariatur cillum",
-                        "role": "eiusmod ut"
-                    },
-                    {
-                        "full_name": "ipsum enim",
-                        "role": "exercitation minim culpa reprehenderit c"
-                    }
-                ],
-                "book_series": {
-                    "title": "occaecat reprehenderit incidid",
-                    "volume": "tempor quis culpa aliqua"
-                },
-                "collaboration": [
-                    "nulla est enim",
-                    "nostrud laborum aliqua Lorem proident",
-                    "et"
-                ],
-                "dois": [
-                    "10.07220386931.8/y+-KpZ&0!",
-                    "10.6181/*bSAtoI",
-                    "10.78/!5,e3$&q",
-                    "10.14597/k",
-                    "10.406371814.8438568/#KPvuHayD("
-                ],
-                "imprint": {
-                    "date": "dddd-dd-dd",
-                    "place": "esse",
-                    "publisher": "adipisicing elit"
-                },
-                "misc": [
-                    "in veniam minim voluptate est",
-                    "qui deserunt sit Duis elit",
-                    "id deserunt velit proident Excepteur",
-                    "aute"
-                ],
-                "number": 55020623,
-                "persistent_identifiers": [
-                    "eu enim",
-                    "eiusmod in sunt cupidatat consectetur"
-                ],
-                "publication_info": {
-                    "artid": "ex incididunt",
-                    "cnum": "esse minim tempor sed ",
-                    "isbn": "nulla do consectetur",
-                    "journal_issue": "reprehenderit proident ea",
-                    "journal_title": "aute",
-                    "journal_volume": "velit commodo labore exercitation ad",
-                    "page_end": "amet",
-                    "page_start": "in",
-                    "reportnumber": "ut aliquip dolor Duis laboris",
-                    "year": 1239
-                },
-                "texkey": "sint ut",
-                "titles": [
-                    {
-                        "source": "proident exercitation",
-                        "subtitle": "ut dolor mollit",
-                        "title": "qui fugiat consectetur"
-                    },
-                    {
-                        "source": "ullamco Duis non",
-                        "subtitle": "ea ipsum",
-                        "title": "ipsum veniam sunt nulla"
-                    },
-                    {
-                        "source": "officia sunt ullamco Lorem",
-                        "subtitle": "irure elit",
-                        "title": "id aliqua Duis minim in"
-                    },
-                    {
-                        "source": "ullamco est fugiat Excepteur veniam",
-                        "subtitle": "do incididunt",
-                        "title": "ad voluptate anim"
-                    }
-                ],
-                "urls": [
-                    {
-                        "description": "consectetur enim sunt",
-                        "value": "http://1>E,"
-                    },
-                    {
-                        "description": "amet",
-                        "value": "http://1r\\aV)gK$bU"
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": true,
-            "raw_refs": [
-                {
-                    "position": "dolore laboris",
-                    "schema": "anim",
-                    "source": "qui nisi amet",
-                    "value": "eu Excepteur aliquip velit"
-                },
-                {
-                    "position": "in pariatur ut fugiat sunt",
-                    "schema": "sint nulla esse",
-                    "source": "est sed amet deserunt officia",
-                    "value": "Ut in elit irure"
-                },
-                {
-                    "position": "in",
-                    "schema": "fugiat reprehenderit voluptate",
-                    "source": "sunt",
-                    "value": "et officia Excepteur exercitation"
-                }
-            ],
-            "record": {
-                "$ref": "http://1"
-            },
-            "reference": {
-                "arxiv_eprints": [
-                    "9441!9474",
-                    "rSrn/1",
-                    "2958?0780"
-                ],
-                "authors": [
-                    {
-                        "full_name": "dolore esse aliquip cupidatat",
-                        "role": "anim"
-                    },
-                    {
-                        "full_name": "do laboris consectetur reprehenderit amet",
-                        "role": "elit amet"
-                    },
-                    {
-                        "full_name": "irure",
-                        "role": "nulla commodo"
-                    },
-                    {
-                        "full_name": "enim dolore qui veniam",
-                        "role": "qui"
-                    }
-                ],
-                "book_series": {
-                    "title": "et mollit",
-                    "volume": "ea non amet"
-                },
-                "collaboration": [
-                    "ut culpa incididunt",
-                    "veniam in ad exercitation dolore",
-                    "elit aute ea non",
-                    "deserunt proident",
-                    "aliqua ea incididunt"
-                ],
-                "dois": [
-                    "10.6135581.03964125/!xh(%&{",
-                    "10.19341242956.877540669/*EWq@? Ae",
-                    "10.87932.4299995/XqDDlu#m",
-                    "10.588435435.6677/:<A{+'",
-                    "10.53750.9924804068/z9+e]tAc1u"
-                ],
-                "imprint": {
-                    "date": "dddd-dd-dd",
-                    "place": "tempor do",
-                    "publisher": "pariatur velit sed do"
-                },
-                "misc": [
-                    "magna est",
-                    "eu anim labore",
-                    "ex anim",
-                    "aute quis id et qui"
-                ],
-                "number": 28737237,
-                "persistent_identifiers": [
-                    "occaecat nostrud in",
-                    "eu in nisi enim",
-                    "fugiat voluptate aute dolor sint",
-                    "quis nostrud dolore",
-                    "officia nisi"
-                ],
-                "publication_info": {
-                    "artid": "labore elit",
-                    "cnum": "mollit in in do",
-                    "isbn": "commodo ad dolore consequat",
-                    "journal_issue": "reprehenderit ut commodo",
-                    "journal_title": "cupidatat fugiat",
-                    "journal_volume": "nostrud do exercitation sit",
-                    "page_end": "ut aute",
-                    "page_start": "veniam dolore aliqua",
-                    "reportnumber": "dolor quis fugiat",
-                    "year": 1218
-                },
-                "texkey": "anim in",
-                "titles": [
-                    {
-                        "source": "in Lorem",
-                        "subtitle": "cillum et",
-                        "title": "culpa dolor"
-                    },
-                    {
-                        "source": "ipsum voluptate",
-                        "subtitle": "reprehenderit Excepteur incididunt eu nisi",
-                        "title": "ut do "
-                    }
-                ],
-                "urls": [
-                    {
-                        "description": "enim",
-                        "value": "http://1$'h#)\"cr"
-                    },
-                    {
-                        "description": "labore dolore",
-                        "value": "http://1DlI"
-                    },
-                    {
-                        "description": "elit",
-                        "value": "http://10Q#W2"
-                    },
-                    {
-                        "description": "commodo eu mollit minim consectetur",
-                        "value": "http://1pa=g\\\""
-                    },
-                    {
-                        "description": "elit cupidatat quis eu",
-                        "value": "http://1~;MLq"
+                        "description": "sed",
+                        "value": "http://1^7++%S0J`{"
                     }
                 ]
             }
@@ -1684,32 +854,47 @@
     "report_numbers": [
         {
             "hidden": true,
-            "source": "laborum",
-            "value": "laboris"
+            "source": "dolore nulla cupi",
+            "value": "ex"
+        },
+        {
+            "hidden": true,
+            "source": "ip",
+            "value": "dolor tempor"
         },
         {
             "hidden": false,
-            "source": "reprehenderit cupidatat",
-            "value": "ipsum consequat non labore commodo"
+            "source": "consequat Duis",
+            "value": "sit fugiat"
+        },
+        {
+            "hidden": true,
+            "source": "Lorem Duis",
+            "value": "qui veniam deserunt quis aliqua"
+        },
+        {
+            "hidden": false,
+            "source": "consequat dolore aliqua aute in",
+            "value": "laborum"
         }
     ],
     "self": {
-        "$ref": "http://1~V"
+        "$ref": "http://1Sh4If+8{"
     },
     "special_collections": [
-        "D0-INTERNAL-NOTE",
-        "CDS"
+        "CDF-NOTE"
     ],
     "succeeding_entry": {
-        "isbn": "594159548X",
+        "isbn": "9781829079214",
         "record": {
-            "$ref": "http://1]RJE"
+            "$ref": "http://1M=9*\\F"
         },
-        "relationship_code": "sed quis culpa magna"
+        "relationship_code": "magna nulla dolore"
     },
     "texkeys": [
-        "ullamco irure consequat tempor id",
-        "cupidatat Duis labore aliqua"
+        "cupidatat in nisi aliqua",
+        "occaecat dolore exercitation dolor",
+        "irure qui ea reprehenderit et"
     ],
     "thesis_info": {
         "date": "dddd-dd-dd",
@@ -1717,51 +902,77 @@
         "degree_type": "habilitation",
         "institutions": [
             {
-                "curated_relation": true,
-                "name": "fugiat mollit ullamco minim",
+                "curated_relation": false,
+                "name": "cupidatat sit et dolor ex",
                 "record": {
-                    "$ref": "http://1Z.Pu"
+                    "$ref": "http://1}^%`rfjg"
+                }
+            },
+            {
+                "curated_relation": true,
+                "name": "eu incididunt sunt",
+                "record": {
+                    "$ref": "http://1.N#8nl{Hg"
+                }
+            },
+            {
+                "curated_relation": true,
+                "name": "ipsum id",
+                "record": {
+                    "$ref": "http://1\"7l"
+                }
+            },
+            {
+                "curated_relation": true,
+                "name": "laborum",
+                "record": {
+                    "$ref": "http://17P_=0"
                 }
             },
             {
                 "curated_relation": false,
-                "name": "aliqua",
+                "name": "Ut voluptate pariatur eu esse",
                 "record": {
-                    "$ref": "http://16Et48"
+                    "$ref": "http://17_h"
                 }
             }
         ]
     },
     "title_translations": [
         {
-            "language": "IV",
-            "source": "in consectetur",
-            "subtitle": "Excepteur proident in esse",
-            "title": "qui nostrud"
+            "language": "GK",
+            "source": "amet",
+            "subtitle": "enim amet cillum exercitation",
+            "title": "consectetur nulla dolor Ut"
         },
         {
-            "language": "PC",
-            "source": "exercitation dolor",
-            "subtitle": "sit",
-            "title": "eu aliquip Duis ve"
+            "language": "9_",
+            "source": "reprehenderit sunt cupidatat in ut",
+            "subtitle": "anim Lorem ea ex",
+            "title": "elit velit et aute sit"
         }
     ],
     "titles": [
         {
-            "source": "Lorem velit do",
-            "subtitle": "velit et sed dolor",
-            "title": "anim incididunt pariatur magna labore"
+            "source": "laborum irure ullamco",
+            "subtitle": "occaecat do nulla culpa fugiat",
+            "title": "Excepteur aute"
         },
         {
-            "source": "do labori",
-            "subtitle": "velit dolor",
-            "title": "aute deserunt "
+            "source": "minim ",
+            "subtitle": "quis est nisi dolor velit",
+            "title": "ea aute minim fugiat"
+        },
+        {
+            "source": "laboris no",
+            "subtitle": "sunt elit adipisicing",
+            "title": "amet velit"
         }
     ],
     "urls": [
         {
-            "description": "et",
-            "value": "http://1 jyk|P S,A"
+            "description": "eiusmod ut non et D",
+            "value": "http://1Q|7w"
         }
     ],
     "withdrawn": false

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -1,191 +1,213 @@
 {
     "ICN": [
-        "ut ut reprehenderit veniam quis",
-        "consectetur adipisicing cupidatat proident sint",
-        "magna ut"
+        "laborum nulla incididunt mollit",
+        "sit dolore"
     ],
     "_collections": [
-        "id magna aute"
+        "in cillum velit laborum",
+        "non",
+        "fugiat dolore esse",
+        "proident qui "
     ],
     "_private_notes": [
         {
-            "source": "laborum Lorem",
-            "value": "laborum Ut id ad"
+            "source": "aliquip in sunt",
+            "value": "magna est quis"
         },
         {
-            "source": "esse nostrud fugiat veniam",
-            "value": "esse ut sit magna"
-        },
-        {
-            "source": "sunt voluptate",
-            "value": "laborum velit"
+            "source": "dolo",
+            "value": "aute sunt sit mollit"
         }
     ],
     "address": [
         {
-            "city": "sint enim ut do in",
-            "country_code": "RU",
-            "latitude": -79299546,
-            "longitude": 8840267,
-            "original address": "ullamco nulla in",
-            "postal_code": "sit ut",
-            "state": "dolor labore ullamco"
+            "city": "ullamco Lorem veniam occaecat",
+            "country_code": "GT",
+            "latitude": 61172909,
+            "longitude": -99793256,
+            "original address": "dolore deserunt officia in cillum",
+            "postal_code": "occaecat ad ut Lorem ut",
+            "state": "magna cup"
         },
         {
-            "city": "minim",
-            "country_code": "NA",
-            "latitude": -81533439,
-            "longitude": -13687772,
-            "original address": "Duis ad deserunt",
-            "postal_code": "sit laboris",
-            "state": "in Duis nostrud labore ea"
-        },
-        {
-            "city": "enim proident ipsum",
-            "country_code": "YT",
-            "latitude": -25011692,
-            "longitude": 75978759,
-            "original address": "nisi d",
-            "postal_code": "non mollit laboris",
-            "state": "do"
+            "city": "reprehenderit in est labore",
+            "country_code": "AF",
+            "latitude": -48519889,
+            "longitude": 84165132,
+            "original address": "qui deserunt Lorem in",
+            "postal_code": "pariatur aliqua elit",
+            "state": "dolor"
         }
     ],
-    "control_number": 11219881,
+    "control_number": 95185544,
     "core": false,
     "deleted": true,
     "department": [
-        "non consequat voluptate adipisicing",
-        "Duis consectetur",
-        "ex amet quis",
-        "labore"
+        "dolore id sunt veniam do",
+        "consequat irure aute",
+        "officia",
+        "ullamco eu eiusmod velit ex",
+        "qui"
     ],
-    "department_acronym": "ad",
+    "department_acronym": "ut fugiat amet Lorem eu",
     "extra_words": [
-        "Duis consequat"
+        "et"
     ],
     "field_activity": [
-        "Other",
-        "University",
-        "Other"
+        "Research Center",
+        "Company"
     ],
     "historical_data": [
-        "aliquip consequat eu Duis adipisicing"
+        "reprehenderit in",
+        "tempor nulla sint velit nostrud",
+        "laboris",
+        "veniam laborum",
+        "anim"
     ],
     "ids": [
         {
             "type": "HAL",
-            "value": "63"
+            "value": "89728870"
         },
         {
             "type": "HAL",
-            "value": "75802151"
+            "value": "6453080179"
         },
         {
             "type": "HAL",
-            "value": "439776"
+            "value": "37872938"
         },
         {
             "type": "HAL",
-            "value": "09714011"
+            "value": "4"
         },
         {
             "type": "HAL",
-            "value": "278327688"
+            "value": "20"
         }
     ],
     "inspire_categories": [
         {
+            "source": "curator",
+            "term": "Lattice"
+        },
+        {
             "source": "arxiv",
-            "term": "Astrophysics"
+            "term": "Data Analysis and Statistics"
         },
         {
             "source": "magpie",
-            "term": "Phenomenology-HEP"
+            "term": "Theory-Nucl"
+        },
+        {
+            "source": "curator",
+            "term": "Theory-Nucl"
+        },
+        {
+            "source": "curator",
+            "term": "Computing"
         }
     ],
     "institution": [
-        "consectetur consequat",
-        "ullamco id dolore",
-        "Duis eu elit aute"
+        "in sit aute Ut",
+        "aute aliquip",
+        "dolore"
     ],
-    "institution_acronym": "ipsum do",
+    "institution_acronym": "dolor irure magna commodo",
+    "legacy_creation_date": "4072-01-10T07:14:00.409Z",
     "location": {
-        "latitude": 80905372,
-        "longitude": -37411804
+        "latitude": -7812816,
+        "longitude": -60246689
     },
     "name_variants": [
         {
-            "source": "est",
-            "value": "cillum co"
+            "source": "ex",
+            "value": "laboris ex qui mollit"
         },
         {
-            "source": "ut Duis ea magna",
-            "value": "do"
+            "source": "voluptate consectetur tempo",
+            "value": "proident nulla"
         },
         {
-            "source": "proident reprehenderit non anim esse",
-            "value": "in"
+            "source": "et adipisicing exercitation Ut",
+            "value": "in id aliqua irure"
         }
     ],
     "new_record": {
-        "$ref": "http://1e+'%;C7wkx"
+        "$ref": "http://1roaCO7"
     },
     "public_notes": [
         {
-            "source": "sit est incididunt se",
-            "value": "elit irure ipsum esse"
+            "source": "dolore",
+            "value": "aliqua"
+        },
+        {
+            "source": "dolor",
+            "value": "Excepteur reprehenderi"
         }
     ],
     "related_institutes": [
         {
-            "curated_relation": true,
-            "name": "quis",
+            "curated_relation": false,
+            "name": "",
             "record": {
-                "$ref": "http://1Y"
+                "$ref": "http://1Z%\"lqgjx"
             },
-            "relation_type": "superseded"
+            "relation_type": "parent"
         },
         {
             "curated_relation": false,
-            "name": "velit eu ex elit ea",
+            "name": "ut dolor",
             "record": {
-                "$ref": "http://1&Pj"
-            },
-            "relation_type": "successor"
-        },
-        {
-            "curated_relation": true,
-            "name": "officia ullamco Lorem tempor Ut",
-            "record": {
-                "$ref": "http://1"
-            },
-            "relation_type": "superseded"
-        },
-        {
-            "curated_relation": true,
-            "name": "in",
-            "record": {
-                "$ref": "http://1-Zuy{EE"
+                "$ref": "http://12"
             },
             "relation_type": "predecessor"
         },
         {
             "curated_relation": true,
-            "name": "fugia",
+            "name": "pariatur",
             "record": {
-                "$ref": "http://108p1"
+                "$ref": "http://1_`>@{eC("
+            },
+            "relation_type": "predecessor"
+        },
+        {
+            "curated_relation": true,
+            "name": "tempor ipsum dolore ut",
+            "record": {
+                "$ref": "http://1rV{zz"
+            },
+            "relation_type": "parent"
+        },
+        {
+            "curated_relation": false,
+            "name": "occaecat consectetur",
+            "record": {
+                "$ref": "http://1J)$2~"
             },
             "relation_type": "superseded"
         }
     ],
     "self": {
-        "$ref": "http://1"
+        "$ref": "http://1(4YU1"
     },
-    "time_zone": "there",
+    "time_zone": "be",
     "urls": [
         {
-            "description": "sed id consectetur in",
-            "value": "http://1aBe"
+            "description": "dolore",
+            "value": "http://1V!Assv("
+        },
+        {
+            "description": "eu ad in",
+            "value": "http://1Mv"
+        },
+        {
+            "description": "deserunt qui elit",
+            "value": "http://16}"
+        },
+        {
+            "description": "culpa",
+            "value": "http://1;=8"
         }
     ]
 }

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -1,160 +1,193 @@
 {
     "_collections": [
-        "incididunt",
-        "dolore do"
+        "elit"
     ],
     "_private_notes": [
         {
-            "source": "exercitation deserunt aliquip",
-            "value": "deserunt veniam"
+            "source": "proident",
+            "value": "Lorem"
         }
     ],
     "address": [
         {
-            "city": "fugiat ex consectetur",
-            "country_code": "DO",
-            "latitude": 73759097,
-            "longitude": -16319288,
-            "original address": "ea velit ullamco qui consequat",
-            "postal_code": "mollit fugiat",
-            "state": "proident aute"
+            "city": "ex culpa ipsum Excepteur in",
+            "country_code": "BY",
+            "latitude": -67973465,
+            "longitude": -73349897,
+            "original address": "voluptate",
+            "postal_code": "mollit sed in",
+            "state": "Duis sunt non quis occaecat"
         },
         {
-            "city": "eiusmod",
-            "country_code": "KY",
-            "latitude": -63214525,
-            "longitude": -84500297,
-            "original address": "dolore ullamco sed",
-            "postal_code": "anim cupidatat laborum ",
-            "state": "nostrud pariatur dolor"
+            "city": "in",
+            "country_code": "NO",
+            "latitude": 14885918,
+            "longitude": 84677950,
+            "original address": "aliquip",
+            "postal_code": "irure consectetur",
+            "state": "occaecat minim"
+        },
+        {
+            "city": "velit aute ul",
+            "country_code": "US",
+            "latitude": -5099862,
+            "longitude": 93294357,
+            "original address": "sunt eu in nisi",
+            "postal_code": "ut voluptate",
+            "state": "cupidatat"
+        },
+        {
+            "city": "cillum Lorem in ea esse",
+            "country_code": "NO",
+            "latitude": 60130405,
+            "longitude": 18776889,
+            "original address": "incididunt",
+            "postal_code": "ut",
+            "state": "consectetur sed dolor non"
+        },
+        {
+            "city": "minim",
+            "country_code": "UA",
+            "latitude": -25355833,
+            "longitude": -42503065,
+            "original address": "laborum proident eiusmod quis",
+            "postal_code": "dolore",
+            "state": "pariatur in"
         }
     ],
     "closed_date": "dddd-dd-dd",
     "contact_details": [
         {
-            "email": "WKdDf9TG4Bf@mNEUI.wir",
-            "name": "aute quis"
+            "email": "af3WABoe@yIvxjosQPSqGMKSKJWrwJRaaycStRHYRg.ayp",
+            "name": "officia"
         },
         {
-            "email": "tC2AkWAN@eopENKIhzaf.xt",
-            "name": "deserunt esse exercitation"
+            "email": "5BX4Rwbx3@xYefMaqxDPxDQpYy.ptky",
+            "name": "et sunt voluptate do"
         },
         {
-            "email": "snvOdJ2JL@uaFULsk.yvz",
-            "name": "laboris dolore"
+            "email": "KO4MZMp5jxjt@DtoVozvDdvUfSupV.yd",
+            "name": "non do enim"
+        },
+        {
+            "email": "1SPymEV@MisSPimhqiCoAJua.tc",
+            "name": "ea"
+        },
+        {
+            "email": "o4-1IcrhNzyWg0q@rvpQAndpJYrbwRTdaDdmACePo.dwpa",
+            "name": "esse"
         }
     ],
-    "control_number": 68628858,
+    "control_number": -66114502,
     "deadline_date": "dddd-dd-dd",
     "deleted": true,
-    "description": "Duis Excepteur",
+    "description": "aliqua quis officia",
     "experiments": [
         {
             "curated_relation": false,
-            "name": "aliqua commodo est elit pariatur",
+            "name": "in culpa consequat",
             "record": {
-                "$ref": "http://1q.mb!#/"
+                "$ref": "http://15~"
             }
         },
         {
             "curated_relation": false,
-            "name": "cupidatat non",
+            "name": "quis eiusmod et",
             "record": {
-                "$ref": "http://1~LRO"
+                "$ref": "http://1uJ}?D:t9"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "eu culpa quis voluptate cupidatat",
+            "record": {
+                "$ref": "http://1!]L7zX{"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "Duis deserunt voluptate sint Ut",
+            "record": {
+                "$ref": "http://1?|buQ2>u*"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "quis nostrud ut non",
+            "record": {
+                "$ref": "http://12c2($%"
             }
         }
     ],
     "inspire_categories": [
         {
-            "source": "user",
-            "term": "Phenomenology-HEP"
-        },
-        {
-            "source": "magpie",
-            "term": "Gravitation and Cosmology"
-        },
-        {
             "source": "undefined",
-            "term": "Theory-Nucl"
+            "term": "Other"
+        },
+        {
+            "source": "curator",
+            "term": "Experiment-Nucl"
         }
     ],
     "institutions": [
         {
-            "curated_relation": true,
-            "name": "aute minim commodo non",
-            "record": {
-                "$ref": "http://1kZ?"
-            }
-        },
-        {
-            "curated_relation": true,
-            "name": "ipsum deserunt magna",
-            "record": {
-                "$ref": "http://1XP\","
-            }
-        },
-        {
             "curated_relation": false,
-            "name": "id",
+            "name": "aute Ut dolore reprehenderit",
             "record": {
-                "$ref": "http://1yFNjQX5~+1"
-            }
-        },
-        {
-            "curated_relation": true,
-            "name": "ipsum",
-            "record": {
-                "$ref": "http://1qL.\""
+                "$ref": "http://1"
             }
         }
     ],
+    "legacy_creation_date": "3292-10-04T19:28:48.495Z",
     "new_record": {
-        "$ref": "http://1g5}M[RH "
+        "$ref": "http://16ZNzV[Y}_w"
     },
-    "position": "sint magna occaecat in",
+    "position": "id eu culpa",
     "public_notes": [
         {
-            "source": "voluptate ex",
-            "value": "ex proident"
+            "source": "incididunt cupidatat sint do culpa",
+            "value": "pariatur eu"
+        },
+        {
+            "source": "ullamco id dolor",
+            "value": "dolore"
+        },
+        {
+            "source": "Duis aliquip",
+            "value": "irure ea nulla consequat"
         }
     ],
     "ranks": [
-        "OTHER",
-        "VISITOR"
+        "MASTER",
+        "SENIOR",
+        "STAFF",
+        "PHD",
+        "OTHER"
     ],
     "reference_email": [
-        "9r0P@ylebkPLYMEJNPmfTRkpzxSTz.pbq",
-        "6AlZO8X@AVxrBdQft.umup"
+        "Fsj@uPdwAwEqVNTapPkNFZLcHv.poqn"
     ],
     "regions": [
-        "Africa",
-        "Australasia",
-        "South America",
-        "North America"
+        "North America",
+        "Asia",
+        "North America",
+        "Asia"
     ],
     "self": {
-        "$ref": "http://1}Q?#5m"
+        "$ref": "http://1KB2~3zef="
     },
     "urls": [
         {
-            "description": "laboris",
+            "description": "Excepteur Ut ex sunt",
+            "value": "http://1mA=7wQ4"
+        },
+        {
+            "description": "elit amet mollit ex",
+            "value": "http://1ox%R"
+        },
+        {
+            "description": "elit sint",
             "value": "http://1"
-        },
-        {
-            "description": "magna ",
-            "value": "http://1mKh{"
-        },
-        {
-            "description": "ex voluptate aute",
-            "value": "http://1,G\""
-        },
-        {
-            "description": "Lorem ipsum velit",
-            "value": "http://1Aj6v!%m"
-        },
-        {
-            "description": "ullamco pariatur in mollit",
-            "value": "http://17W}_"
         }
     ]
 }

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -1,141 +1,163 @@
 {
     "_collections": [
-        "non",
-        "dolor"
+        "tem",
+        "sunt esse aliqua ut commodo",
+        "ad exe"
     ],
     "_private_notes": [
         {
-            "source": "pariatur sit ",
-            "value": "consequat ea Duis"
+            "source": "aliqua reprehenderit officia non",
+            "value": "fugiat proident Lorem magna"
         },
         {
-            "source": "et consectetur eiusmod mollit",
-            "value": "exercitation labore"
+            "source": "eu in",
+            "value": "adipisicing amet"
+        },
+        {
+            "source": "veniam minim incididunt ",
+            "value": "ut magna est eu ut"
+        },
+        {
+            "source": "incididunt velit ipsum laborum ullamco",
+            "value": "anim"
         }
     ],
     "coden": [
-        "9FS9",
-        "WDWS",
-        "DK7C"
+        "ZZS0A",
+        "HJ5NN",
+        "YSCSIU",
+        "15E2FS"
     ],
-    "control_number": -85111166,
-    "deleted": true,
-    "history": "quis esse",
+    "control_number": -50167608,
+    "deleted": false,
+    "history": "anim laborum Excepteur enim",
     "issn": [
         {
-            "comment": "exercitation dolore",
-            "medium": "online",
-            "value": "5308-969X"
-        },
-        {
-            "comment": "nulla eu ut dolor deserunt",
+            "comment": "dolor",
             "medium": "print",
-            "value": "1109-0656"
+            "value": "7055-1367"
         },
         {
-            "comment": "culpa",
-            "medium": "print",
-            "value": "6467-3097"
-        },
-        {
-            "comment": "in dolor nostrud",
+            "comment": "reprehenderit ut eu magna",
             "medium": "online",
-            "value": "1521-894X"
+            "value": "8019-1590"
         }
     ],
-    "journal_handling": "dolor",
+    "journal_handling": "tempor",
     "journal_titles": [
         {
-            "source": "in Ut",
-            "subtitle": "Duis ipsum do est",
-            "title": "enim adipisicing"
-        },
-        {
-            "source": "eu adipisicing deserunt consectetur Lorem",
-            "subtitle": "elit",
-            "title": "magna voluptate sunt eu commodo"
+            "source": "ut aliquip",
+            "subtitle": "qui Ut culpa",
+            "title": "do in ipsum proident dolor"
         }
     ],
-    "license": "it",
+    "legacy_creation_date": "4738-12-15T20:54:05.646Z",
+    "license": "probably",
     "license_urls": [
         {
-            "description": "sunt in eu consequat",
-            "value": "http://1=!1o'Q.2)"
+            "description": "sunt dolore eiusmod consequat",
+            "value": "http://1o<%"
         },
         {
-            "description": "aliqua",
-            "value": "http://1Le2i{kR5T|"
+            "description": "Duis ad non",
+            "value": "http://1>OT6ZUN:xK"
         },
         {
-            "description": "v",
-            "value": "http://1|z+O|J"
+            "description": "nostrud adipisicing labore laboris",
+            "value": "http://1B"
         }
     ],
     "new_record": {
-        "$ref": "http://1Hf9u%Ci|~r"
+        "$ref": "http://1O-"
     },
-    "peer_reviewed": true,
+    "peer_reviewed": false,
     "public_notes": [
         {
-            "source": "sint",
-            "value": "Lorem ut sed ea Ut"
+            "source": "minim sint amet dolor reprehenderit",
+            "value": "ut sunt pariatur sint dolore"
         },
         {
-            "source": "aute reprehenderit veniam amet cupidatat",
-            "value": "enim in ipsum"
+            "source": "commodo ea",
+            "value": "anim in in u"
         },
         {
-            "source": "dolore tempor esse in",
-            "value": "ut"
+            "source": "Excepteur cupidatat in in",
+            "value": "sed ea proident"
+        },
+        {
+            "source": "incididunt ea",
+            "value": "dolor ipsum laboris eu ea"
         }
     ],
     "publisher": [
-        "labore"
+        "dolore ad sed ipsum",
+        "consequat Duis est magna in",
+        "dolor laborum eiusmod dolor",
+        "fugiat",
+        "Excepteur voluptate exercitation"
     ],
     "relation": {
         "curated_relation": false,
-        "issn": "7795-7416",
+        "issn": "5293-0205",
         "record": {
-            "$ref": "http://1Y4Oz$2D"
+            "$ref": "http://1R&}n_=<%\""
         },
         "relation": "superseded record"
     },
     "self": {
-        "$ref": "http://1"
+        "$ref": "http://1c0u,8"
     },
     "short_titles": [
         {
-            "source": "do ut officia",
-            "subtitle": "pariatur dolore ex non et",
-            "title": "aliquip occaecat adipisicing in"
+            "source": "labore officia mollit elit sit",
+            "subtitle": "Excepteur",
+            "title": "in irure incididunt dolore"
         },
         {
-            "source": "cillum",
-            "subtitle": "exercitation",
-            "title": "enim"
+            "source": "nisi ad",
+            "subtitle": "do tempor qui proident anim",
+            "title": "deserunt mollit Lorem laboris"
         },
         {
-            "source": "officia consectetur",
-            "subtitle": "consequat deserunt Excepteur",
-            "title": "nostrud mollit tempor ex magna"
+            "source": "nostrud",
+            "subtitle": "eiusmod sint dolor",
+            "title": "non"
         },
         {
-            "source": "dolore",
-            "subtitle": "id Lorem eu",
-            "title": "in dolor et"
+            "source": "id veniam est dolor",
+            "subtitle": "cupidatat ut",
+            "title": "magna Lorem"
         }
     ],
     "title_variants": [
         {
-            "source": "culpa consequat nulla ex e",
-            "subtitle": "deserunt in irure elit aute",
-            "title": "dolor deserunt"
+            "source": "id",
+            "subtitle": "",
+            "title": "laborum ea consequat"
+        },
+        {
+            "source": "ut ea",
+            "subtitle": "qui ex cupidatat veniam e",
+            "title": "anim culpa"
+        },
+        {
+            "source": "ipsum proident",
+            "subtitle": "ullamco cupidatat incididunt occaecat",
+            "title": "velit Excepteur labore"
         }
     ],
     "urls": [
         {
-            "description": "officia laboris",
-            "value": "http://1Jp.HrW"
+            "description": "non reprehenderit id nulla anim",
+            "value": "http://1W^!.qNLC=n"
+        },
+        {
+            "description": "ut Excepteur minim ut",
+            "value": "http://10&k&?QJrm!"
+        },
+        {
+            "description": "eiusmod",
+            "value": "http://1Gq"
         }
     ]
 }


### PR DESCRIPTION
* NEW Introduces new legacy_creation_date field that allows to
  preserve the creation date when migrating from INSPIRE legacy.

* Ideally this field could disappear, after having implemented
  a migration script that would map legacy_creation_date back
  to the proper database column.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>