### PR TITLE
schemas: external_system_identifiers changes

### DIFF
--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -61,6 +61,34 @@
         "deleted": {
             "type": "boolean"
         },
+        "external_system_identifiers": {
+            "items": {
+                "anyOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "SPIRES"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "pattern": "^CONF-\\d+$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "value"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "inspire_categories": {
             "items": {
                 "$ref": "elements/inspire_field.json"

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -114,6 +114,34 @@
             "type": "array",
             "uniqueItems": true
         },
+        "external_system_identifiers": {
+            "items": {
+                "anyOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "SPIRES"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "pattern": "^EXPERIMENT-\\d+$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "value"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "free_keywords": {
             "items": {
                 "title": "Free keyword",

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -58,6 +58,54 @@
             "title": "Department acronym",
             "type": "string"
         },
+        "external_system_identifiers": {
+            "items": {
+                "anyOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "HAL"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "pattern": "^\\d+$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "value"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "SPIRES"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "pattern": "^INST-\\d+$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "value"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "extra_words": {
             "items": {
                 "type": "string"
@@ -84,34 +132,6 @@
                 "type": "string"
             },
             "type": "array"
-        },
-        "ids": {
-            "items": {
-                "anyOf": [
-                    {
-                        "additionalProperties": false,
-                        "properties": {
-                            "type": {
-                                "enum": [
-                                    "HAL"
-                                ],
-                                "type": "string"
-                            },
-                            "value": {
-                                "pattern": "^\\d+$",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "value"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
-            "type": "array",
-            "uniqueItems": true
         },
         "inspire_categories": {
             "items": {

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -75,6 +75,34 @@
             "type": "array",
             "uniqueItems": true
         },
+        "external_system_identifiers": {
+            "items": {
+                "anyOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "SPIRES"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "pattern": "^JOBS-\\d+$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "value"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "inspire_categories": {
             "items": {
                 "$ref": "elements/inspire_field.json"

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -1,326 +1,297 @@
 {
     "_collections": [
-        "sit",
-        "ullamco enim elit",
-        "sed dolore Lorem deserunt veniam"
+        "sit sint officia ad deserunt"
     ],
     "_private_notes": [
         {
-            "source": "anim consectetur ullamco",
-            "value": "incididunt"
+            "source": "nostrud",
+            "value": "ut"
         }
     ],
     "acquisition_source": {
-        "date": "ut",
-        "email": "jY9qYs@S.iqtw",
-        "internal_uid": 86801391,
-        "method": "submitter",
-        "orcid": "7599-0307-7526-0482",
-        "source": "non",
-        "submission_number": "laboris in in Duis id"
+        "date": "fugiat",
+        "email": "ZlVWINK@BRmtH.xi",
+        "internal_uid": 63631014,
+        "method": "oai",
+        "orcid": "7857-9765-2950-2423",
+        "source": "ea Lorem",
+        "submission_number": "nulla ex irure labore"
     },
     "advisors": [
         {
             "curated_relation": true,
-            "degree_type": "bachelor",
+            "degree_type": "phd",
             "ids": [
                 {
-                    "schema": "SCOPUS",
-                    "value": "53703912607"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "---K-2----zz"
                 },
                 {
-                    "schema": "SCOPUS",
-                    "value": "5494578861"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "8-c---d----U"
                 }
             ],
-            "name": "in deserunt",
+            "name": "ut ut",
             "record": {
-                "$ref": "http://1@9cR(G=ZO"
+                "$ref": "http://1f2;_#7"
             }
         },
         {
             "curated_relation": false,
-            "degree_type": "habilitation",
+            "degree_type": "laurea",
             "ids": [
                 {
-                    "schema": "SCOPUS",
-                    "value": "76112864156"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "-----Zp--4-M"
                 },
                 {
-                    "schema": "SCOPUS",
-                    "value": "9456852042"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "----Uh--X1-d"
                 },
                 {
-                    "schema": "SCOPUS",
-                    "value": "6611865449"
-                },
-                {
-                    "schema": "SCOPUS",
-                    "value": "6790060904"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "---3hi-lRr--"
                 }
             ],
-            "name": "in nostrud Lorem sit ex",
+            "name": "sunt",
             "record": {
-                "$ref": "http://1w d\""
-            }
-        },
-        {
-            "curated_relation": false,
-            "degree_type": "diploma",
-            "ids": [
-                {
-                    "schema": "SCOPUS",
-                    "value": "0174191655"
-                },
-                {
-                    "schema": "SCOPUS",
-                    "value": "25502504965"
-                },
-                {
-                    "schema": "SCOPUS",
-                    "value": "08612262883"
-                },
-                {
-                    "schema": "SCOPUS",
-                    "value": "12683059071"
-                }
-            ],
-            "name": "dolore incididunt velit tempor",
-            "record": {
-                "$ref": "http://1 "
+                "$ref": "http://1QIjwO"
             }
         },
         {
             "curated_relation": true,
-            "degree_type": "other",
-            "ids": [
-                {
-                    "schema": "SCOPUS",
-                    "value": "7831852122"
-                }
-            ],
-            "name": "Duis velit eiusmod sint",
-            "record": {
-                "$ref": "http://1qC5"
-            }
-        },
-        {
-            "curated_relation": false,
             "degree_type": "master",
             "ids": [
                 {
-                    "schema": "SCOPUS",
-                    "value": "18247276582"
-                },
-                {
-                    "schema": "SCOPUS",
-                    "value": "7626333288"
+                    "schema": "GOOGLESCHOLAR",
+                    "value": "GJ--K-d-eb-m"
                 }
             ],
-            "name": "sint consectetur",
+            "name": "eiusmod incididunt",
             "record": {
-                "$ref": "http://1O)ZY-{*"
+                "$ref": "http://1tJ^9"
             }
         }
     ],
     "birth_date": "dddd-dd-dd",
     "conferences": [
         {
-            "$ref": "http://1I"
+            "$ref": "http://1~;/(H*Khf"
         },
         {
-            "$ref": "http://1dx]PA.4,"
+            "$ref": "http://1f7]S,C"
         },
         {
-            "$ref": "http://1z"
+            "$ref": "http://1"
         }
     ],
-    "control_number": 48068739,
+    "control_number": 14038167,
     "death_date": "dddd-dd-dd",
-    "deleted": false,
+    "deleted": true,
     "email_addresses": [
-        "RyRm1zx3Xfe@qiMYjxiD.abnr"
+        "gW9e5Xjpq69Xfe@TDDtZlWINqKnvXNlbKXpMTyEzfKYu.edz",
+        "YLWoN9T@EqNnHyzwYfXafqoIjAYvZVTnjfuYVHTm.xfyt",
+        "Urm-fo-f8@DLC.ced",
+        "dohLF3V8wEBI@TQHbjSLXMubUHlQNOpD.nqtp",
+        "59ipT7MWt94EVyN@sBmGYlBJ.le"
     ],
     "experiments": [
         {
-            "curated_relation": false,
-            "current": true,
-            "end_year": -79527388,
-            "name": "voluptate veniam dolore",
+            "curated_relation": true,
+            "current": false,
+            "end_year": 20729772,
+            "name": "ad aliqua et Ut sed",
             "record": {
-                "$ref": "http://11S1k+vxR"
+                "$ref": "http://1$}`Y"
             },
-            "start_year": -20808213
+            "start_year": 85756645
         },
         {
             "curated_relation": true,
-            "current": false,
-            "end_year": -48829320,
-            "name": "nulla consectetur eu",
-            "record": {
-                "$ref": "http://1:+@+"
-            },
-            "start_year": -12642041
-        },
-        {
-            "curated_relation": false,
             "current": true,
-            "end_year": -40564202,
-            "name": "anim",
+            "end_year": 52990326,
+            "name": "aliquip proident culpa in ea",
             "record": {
-                "$ref": "http://1uViI^Nh"
+                "$ref": "http://1]k"
             },
-            "start_year": -39688262
+            "start_year": -59275504
         }
     ],
     "ids": [
         {
             "schema": "WIKIPEDIA",
-            "value": "u"
+            "value": "DPV4f8"
+        },
+        {
+            "schema": "WIKIPEDIA",
+            "value": "R"
         }
     ],
     "inspire_categories": [
         {
-            "source": "user",
+            "source": "magpie",
+            "term": "Other"
+        },
+        {
+            "source": "curator",
             "term": "Experiment-HEP"
         }
     ],
-    "legacy_creation_date": "3964-06-08T01:28:41.737Z",
+    "legacy_creation_date": "3410-12-11T13:09:23.102Z",
     "name": {
-        "numeration": "VIII",
-        "preferred_name": "fugiat enim in labore sunt",
-        "title": "Sir",
-        "value": "j(0, @>=Y=ZpyWq~"
+        "numeration": "III",
+        "preferred_name": "voluptate dolor eu culpa",
+        "title": "",
+        "value": "ksy_CqAD, ,F#GW(I"
     },
     "native_name": [
-        "non"
+        "pariatur elit deserunt incididunt",
+        "et dolore elit ut",
+        "pariatur est laboris",
+        "sint est"
     ],
     "new_record": {
-        "$ref": "http://1)1m-^"
+        "$ref": "http://1T$zX{%A^"
     },
     "other_names": [
-        "proident est Lorem exercitation do",
-        "ullamco id nulla",
-        "adipisicing",
-        "Excepteur laboris velit deserunt consequat"
+        "Lorem do aliquip",
+        "ut et",
+        "ad deserunt fugiat incididunt laboris",
+        "dolor proident tempor",
+        "commodo pariatur est dolore cillum"
     ],
     "past_emails_addresses": [
-        "uu3n3eqcwP@ctEovOpjqtMVVnEmlBT.cb",
-        "Jde-aH7DrT9X@gXYCGsvqsGrpeUuozjEJXogeNbhJgbKXY.jor"
+        "QNHAsDKxIj@VPOENYKVSebZJlXcUgsPryszClgwmovGp.svo"
     ],
     "positions": [
         {
-            "_rank": "eiusmod",
+            "_rank": "aliqua",
             "current": true,
             "emails": [
-                "3Ik@lGEUhzviviECeQPFOpWykLLSiaQXNkMj.zykc"
+                "QwaiIl360glhtt@iKLbC.hg",
+                "gz6jYlUsJGt@fdQhsNKCWWpYgCfCcgRsBnNfcsIxVkfz.els"
             ],
             "end_date": "dddd-dd-dd",
             "institution": {
-                "curated_relation": false,
-                "name": "non ",
+                "curated_relation": true,
+                "name": "ut reprehenderit consectetur amet dolor",
                 "record": {
-                    "$ref": "http://1.SPnk%$?"
+                    "$ref": "http://1{vC%e"
                 }
             },
             "old_emails": [
-                "W9x4J@CSCCVZEcA.av",
-                "ur96@MFipuKLUVoIyoxFLcILnBCyZDF.hbf",
-                "zsDttQ@dawhHKIXpMARMhuRP.inkt",
-                "uqx94mntAvjXB@c.ckzr"
-            ],
-            "rank": "OTHER",
-            "start_date": "dddd-dd-dd"
-        },
-        {
-            "_rank": "id deserunt consec",
-            "current": true,
-            "emails": [
-                "q6IVIVW@OplFpNiW.rzw"
-            ],
-            "end_date": "dddd-dd-dd",
-            "institution": {
-                "curated_relation": false,
-                "name": "do dolore",
-                "record": {
-                    "$ref": "http://1QDbX"
-                }
-            },
-            "old_emails": [
-                "RM6@dxVEOfbfahlUbKHDdUPhpmvn.bhu",
-                "oPGXUODCWjP-dlu@lPxHnHnUF.yt",
-                "mjmwVeLPn1iFm@uPfCApeLhY.krb"
+                "mt9h8Waij9Ra@nSOFhtzBcZTkqHfZrEEAkQbD.ag"
             ],
             "rank": "POSTDOC",
             "start_date": "dddd-dd-dd"
         },
         {
-            "_rank": "voluptate",
+            "_rank": "nisi e",
             "current": true,
             "emails": [
-                "2R--EVswK@yYaZHTrZTyinoufvO.tqf",
-                "15gCY3@HPPdgFObeYstZD.syjc",
-                "SjkIXquqFUaUGr9@CBLQjdxOYuIZNcbTBXJHr.po"
+                "9Rb1iwATB1WgJvp@PhuBnIIfoKxgwiWBaexMkUiNsef.ji",
+                "v58@yQgF.ix",
+                "eKF@Xbxup.gxt",
+                "k79n@eNOZEsgixoizJwzogoRA.afv"
+            ],
+            "end_date": "dddd-dd-dd",
+            "institution": {
+                "curated_relation": false,
+                "name": "dolore esse Ut in",
+                "record": {
+                    "$ref": "http://1"
+                }
+            },
+            "old_emails": [
+                "3poq4Sm@Z.eo",
+                "gR9asV@cQOqxB.uyun",
+                "7sxbn@UHiXrTGhIGLBTzEGdnfaApTVin.zuvt"
+            ],
+            "rank": "UNDERGRADUATE",
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "_rank": "anim tempor",
+            "current": true,
+            "emails": [
+                "oZFs4O2YJLiq@mQYVbaHKWTZqkkQTxMRfbyajlkqn.zsn"
             ],
             "end_date": "dddd-dd-dd",
             "institution": {
                 "curated_relation": true,
-                "name": "exercitation occ",
+                "name": "nostrud",
                 "record": {
-                    "$ref": "http://1gL.kZss8v"
+                    "$ref": "http://1C@PVF"
                 }
             },
             "old_emails": [
-                "S3mswLjq@PrUjStmBNVv.emc",
-                "YaphXdBqQU@XFFOy.cibt",
-                "vb2lax53@fXilWWQdKWEWHgzkVOHvpsAtNb.coxh"
+                "mt0RhNaTzRJNU@lBmeYZJAmRdwYlVq.ns",
+                "M9D@UgejIazHcuRf.pp",
+                "bc6SQ9C5UTlRQMj@MpqiFfbtGiJURXkXdiBrEvgXKwAheK.lsf",
+                "ozMGDhs8U@rJHufjojsyacVyKSjsgrxnZado.vx",
+                "SnuJ7@r.at"
             ],
-            "rank": "STAFF",
+            "rank": "OTHER",
             "start_date": "dddd-dd-dd"
         }
     ],
     "previous_names": [
-        "irure labore eu amet laborum",
-        "eu minim veniam in officia"
+        "reprehenderit proident dol",
+        "officia",
+        "Ut esse sint",
+        "Excepteur sit ipsum reprehenderit mollit",
+        "Duis"
     ],
     "prizes": [
-        "cillum eiusmod consectetur nisi culpa",
-        "minim deserunt Excepteur",
-        "enim Lorem do"
+        "nisi",
+        "minim",
+        "esse id dolore dolor aliquip"
     ],
     "public_notes": [
         {
-            "source": "proident Excepteur dolor cupidatat",
-            "value": "et cillum labore ex"
+            "source": "occaecat in fugiat mollit aliqua",
+            "value": "irure labore dolor officia dolore"
+        },
+        {
+            "source": "eiusmod",
+            "value": "nisi proident sunt"
+        },
+        {
+            "source": "aliquip",
+            "value": "in Lorem dolor tempor adipisicing"
         }
     ],
     "self": {
-        "$ref": "http://1B[Lc)28 K"
+        "$ref": "http://1LgA+9%"
     },
     "source": [
         {
             "date_verified": "dddd-dd-dd",
-            "name": "an"
+            "name": "dolor nisi"
         },
         {
             "date_verified": "dddd-dd-dd",
-            "name": "in laborum"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "elit"
-        },
-        {
-            "date_verified": "dddd-dd-dd",
-            "name": "Ut ex sint"
+            "name": "nulla ipsum eu"
         }
     ],
     "status": "active",
     "stub": false,
     "urls": [
         {
-            "description": "aliquip amet magna laboris",
-            "value": "http://1Qs3;"
+            "description": "fugiat laborum occaecat cillum",
+            "value": "http://126"
+        },
+        {
+            "description": "ex cillum sunt",
+            "value": "http://1-jfLe;S"
+        },
+        {
+            "description": "enim",
+            "value": "http://1xvZOl.#jLJ"
+        },
+        {
+            "description": "ut tempor",
+            "value": "http://1"
         }
     ]
 }

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -1,216 +1,208 @@
 {
     "_collections": [
-        "deserunt quis",
-        "ea id dolore",
-        "ullamco commo"
+        "eu",
+        "magna cillum",
+        "sunt dolor",
+        "tempor exercitation enim ",
+        "magna"
     ],
     "_private_notes": [
         {
-            "source": "ipsum aliqua aute qui",
-            "value": "eiusmod"
+            "source": "Excepteur magna sint ipsum",
+            "value": "nisi"
         },
         {
-            "source": "sit sed",
-            "value": "ad dolore ut deserunt Ut"
-        },
-        {
-            "source": "tempor eiusmod",
-            "value": "proident"
-        },
-        {
-            "source": "in in exercitation",
-            "value": "culpa quis magna eu veniam"
-        },
-        {
-            "source": "ci",
-            "value": "reprehenderit Ut velit quis"
+            "source": "dolor voluptate qui labore",
+            "value": "in esse labore occaecat"
         }
     ],
     "acronym": [
-        "proident ut id",
-        "ipsum"
+        "sed commodo",
+        "ipsum in voluptate",
+        "voluptate Ut",
+        "voluptate"
     ],
     "address": [
         {
-            "city": "dolore Lorem voluptate sit",
-            "country_code": "RO",
-            "latitude": -81046160,
-            "longitude": 8553190,
-            "original address": "dolor",
-            "postal_code": "sit ipsum anim Lorem ea",
-            "state": "Ut in cupidatat Lorem"
+            "city": "dolore Lorem non nulla ut",
+            "country_code": "MK",
+            "latitude": -68480015,
+            "longitude": -89112517,
+            "original address": "enim fugiat amet ipsum veniam",
+            "postal_code": "exercitation",
+            "state": "ex anim eiusm"
         },
         {
-            "city": "anim non adipisicing enim eiusmod",
-            "country_code": "AS",
-            "latitude": -55322367,
-            "longitude": 89454463,
-            "original address": "non sint",
-            "postal_code": "amet occaecat commodo",
-            "state": "Ut in veniam occaecat dolor"
+            "city": "dolore consequat",
+            "country_code": "AB",
+            "latitude": -42756208,
+            "longitude": -71966552,
+            "original address": "proident sit",
+            "postal_code": "amet",
+            "state": "nulla occaecat exercitation con"
+        },
+        {
+            "city": "nost",
+            "country_code": "FI",
+            "latitude": -87209112,
+            "longitude": -40741489,
+            "original address": "in laboris pariatur minim ut",
+            "postal_code": "aliqua in anim qui",
+            "state": "in fugiat nulla eu voluptate"
+        },
+        {
+            "city": "ex minim dolor",
+            "country_code": "PS",
+            "latitude": -17911744,
+            "longitude": 62697582,
+            "original address": "non nostrud",
+            "postal_code": "anim laboris velit incididunt",
+            "state": "velit adipisicing commodo"
+        },
+        {
+            "city": "non nisi ipsum",
+            "country_code": "CZ",
+            "latitude": 1630271,
+            "longitude": -66493437,
+            "original address": "laboris eiusmod",
+            "postal_code": "in aliqua",
+            "state": "nostrud minim"
         }
     ],
     "alternative_titles": [
         {
-            "source": "in ullamco culpa",
-            "subtitle": "aliquip exercitation est in",
-            "title": "in est et"
+            "source": "dolor ex",
+            "subtitle": "aliqua incididunt Ut Lorem qui",
+            "title": "sed anim Duis dolore Lorem"
         },
         {
-            "source": "id fugiat deserunt dolor",
-            "subtitle": "eu deserunt sit",
-            "title": "laboris ipsum adipisicing"
-        },
-        {
-            "source": "ut esse Ut do tempor",
-            "subtitle": "ex sunt",
-            "title": "consequat adipisicing ut do"
+            "source": "reprehenderit ex esse consequat",
+            "subtitle": "fugiat commodo Excepteur non",
+            "title": "culpa ut sunt nulla"
         }
     ],
     "closing_date": "dddd-dd-dd",
-    "cnum": "C95-25-84",
+    "cnum": "C88-53-71",
     "contact_details": [
         {
-            "email": "KOWE0Uz@PWnjJlpLmykqmmsP.cbrc",
-            "name": "ut incididunt Lorem"
+            "email": "lp9EFN@arXWxerYlepfLrO.mvlw",
+            "name": "in"
         }
     ],
-    "control_number": 69383439,
-    "deleted": false,
+    "control_number": -36353735,
+    "deleted": true,
+    "external_system_identifiers": [
+        {
+            "type": "SPIRES",
+            "value": "CONF-8613010952"
+        },
+        {
+            "type": "SPIRES",
+            "value": "CONF-03267642288"
+        }
+    ],
     "inspire_categories": [
         {
-            "source": "curator",
-            "term": "Math and Math Physics"
-        },
-        {
-            "source": "magpie",
-            "term": "Astrophysics"
-        },
-        {
-            "source": "curator",
-            "term": "Phenomenology-HEP"
-        },
-        {
-            "source": "curator",
+            "source": "arxiv",
             "term": "Gravitation and Cosmology"
         },
         {
-            "source": "user",
-            "term": "Data Analysis and Statistics"
+            "source": "magpie",
+            "term": "Instrumentation"
+        },
+        {
+            "source": "magpie",
+            "term": "Experiment-HEP"
         }
     ],
     "keywords": [
         {
-            "source": "nulla",
-            "value": "tempor no"
+            "source": "la",
+            "value": "ut sed esse sint"
         },
         {
-            "source": "eiusmod fugiat",
-            "value": "elit eiusmod dolor sit"
+            "source": "cillum in",
+            "value": "in sit"
         },
         {
-            "source": "exercitation",
-            "value": "labore do ut minim sed"
-        },
-        {
-            "source": "non",
-            "value": "dolore occaecat fugiat labore voluptate"
+            "source": "nisi",
+            "value": "aute est ni"
         }
     ],
-    "legacy_creation_date": "3225-01-05T08:47:43.583Z",
+    "legacy_creation_date": "4331-11-27T21:30:11.058Z",
     "new_record": {
-        "$ref": "http://1;w' ~"
+        "$ref": "http://1xhj]w:6h}"
     },
     "opening_date": "dddd-dd-dd",
-    "place": "00+K,lLt1u+*K]xG^&)L[",
+    "place": "f,C8!!t7btgB];UI}_2D@",
     "public_notes": [
         {
-            "source": "qui ut exercitation",
-            "value": "Lorem nulla"
-        },
-        {
-            "source": "veniam magna",
-            "value": "dolore"
-        },
-        {
-            "source": "sit aliqua",
-            "value": "sunt adipisicing"
-        },
-        {
-            "source": "eiusmod",
-            "value": "labore"
-        },
-        {
-            "source": "mollit magna do nostrud deserunt",
-            "value": "ut nulla"
+            "source": "eu in",
+            "value": "ullamco nostrud Ut aliquip aliqua"
         }
     ],
     "self": {
-        "$ref": "http://1*o4&_-Mh9m"
+        "$ref": "http://1I"
     },
     "series": [
         {
-            "name": "occaecat in elit",
-            "number": -84096309
-        },
-        {
-            "name": "ea ipsum cupidatat",
-            "number": 74908301
-        },
-        {
-            "name": "ad proident anim culpa do",
-            "number": -93322903
-        },
-        {
-            "name": "labore deserunt",
-            "number": -7195016
+            "name": "in ut eu",
+            "number": 67142873
         }
     ],
     "short_description": [
         {
-            "source": "sed ut mollit",
-            "value": "id Excepteur cillum ipsum in"
+            "source": "nisi",
+            "value": "consectetur officia"
+        },
+        {
+            "source": "adipisicing com",
+            "value": "anim deserunt"
+        },
+        {
+            "source": "consectetur ad sint",
+            "value": "ut amet repr"
+        },
+        {
+            "source": "dolor",
+            "value": "Duis"
         }
     ],
     "titles": [
         {
-            "source": "reprehenderit ",
-            "subtitle": "culpa proident Excepteur do",
-            "title": "ex"
+            "source": "consequat anim Lorem elit",
+            "subtitle": "exercitation sint eu",
+            "title": "veniam reprehenderit "
         },
         {
-            "source": "minim",
-            "subtitle": "qui irure ex eiusm",
-            "title": "magna"
+            "source": "occaecat sed",
+            "subtitle": "exercitation",
+            "title": "sunt adipisicing sed ad veniam"
         },
         {
-            "source": "enim incididunt ea et",
-            "subtitle": "reprehenderit pariatur occaecat",
-            "title": "ad"
+            "source": "in",
+            "subtitle": "ea deserunt et quis fugiat",
+            "title": "Lorem minim"
         },
         {
-            "source": "minim",
-            "subtitle": "ut aliqua cupidat",
-            "title": "velit Ut"
+            "source": "laborum culpa qui ut",
+            "subtitle": "Ut enim et",
+            "title": "et"
         },
         {
-            "source": "id ipsum aute ad dolor",
-            "subtitle": "ad",
-            "title": "ut"
+            "source": "elit irure cillum dolor aliqua",
+            "subtitle": "nisi officia labore",
+            "title": "elit nostrud minim"
         }
     ],
     "urls": [
         {
-            "description": "proident laborum a",
-            "value": "http://1`^2I3}"
+            "description": "ad culpa tempor occaecat",
+            "value": "http://1`p|7_\""
         },
         {
-            "description": "in veniam",
-            "value": "http://1xX_e#p-"
-        },
-        {
-            "description": "dolore",
-            "value": "http://11Hcl/-q}"
+            "description": "aute quis consectetur qui deserunt",
+            "value": "http://1<6"
         }
     ]
 }

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -1,56 +1,54 @@
 {
     "_collections": [
-        "irure",
-        "ad",
-        "laborum exercitation ut in",
-        "sint aliquip",
-        "officia tempor aliqua Lorem"
+        "non",
+        "amet"
     ],
     "_private_notes": [
         {
-            "source": "adipisicing",
-            "value": "cillum in"
+            "source": "eu ut ex",
+            "value": "aliqua"
         },
         {
-            "source": "id ad aliquip esse eiusmod",
-            "value": "ad dolore"
+            "source": "do pariatur ut",
+            "value": "cillum aute adipisicing ullamco"
         },
         {
-            "source": "adipisicing tempor nulla",
-            "value": "cupi"
-        },
-        {
-            "source": "voluptate nulla eiusmod aliqua cillum",
-            "value": "Duis reprehenderit voluptate"
-        },
-        {
-            "source": "ex sit",
-            "value": "consequat su"
+            "source": "eiusmod a",
+            "value": "pariatur"
         }
     ],
-    "accelerator": "nulla s",
+    "accelerator": "do Lorem minim enim eu",
     "affiliations": [
         {
-            "curated_relation": true,
-            "name": "aliqua ex nostrud culpa",
+            "curated_relation": false,
+            "name": "ut s",
             "record": {
-                "$ref": "http://1jl'"
+                "$ref": "http://18Ozkk"
+            }
+        },
+        {
+            "curated_relation": false,
+            "name": "id",
+            "record": {
+                "$ref": "http://1pj3Yz;i>"
             }
         }
     ],
-    "collaboration": "aute sed non",
+    "collaboration": "non Ut aute nostrud quis",
     "collaboration_alternative_names": [
-        "dolor voluptate ea ex",
-        "tempor Ut velit",
-        "et"
+        "quis commodo",
+        "sit",
+        "officia eu Duis eiusmod",
+        "consectetur veniam laboris dolor",
+        "Lorem"
     ],
     "contact_details": [
         {
-            "email": "ItQbstJNzjcQN@IczxyIiWUyjEDWPUrAtiRDOSVWDFfHDo.fuuo",
-            "name": "fugiat velit incididunt ut"
+            "email": "QbRf2vAlxPFXMN@uVxXEONqPsqyROdgRIJWn.jwrw",
+            "name": "ut"
         }
     ],
-    "control_number": 1914427,
+    "control_number": 81990854,
     "curated_relation": true,
     "date_approved": "dddd-dd-dd",
     "date_cancelled": "dddd-dd-dd",
@@ -59,171 +57,228 @@
     "date_started": "dddd-dd-dd",
     "deleted": true,
     "description": [
-        "in",
-        "eu"
+        "pariatur a"
     ],
     "experiment_names": [
         {
-            "source": "proident",
-            "subtitle": "Duis sit ullamco",
-            "title": "deserunt tempor"
+            "source": "id adipisicing",
+            "subtitle": "in ",
+            "title": "dolor ea reprehenderit"
         },
         {
-            "source": "ut irure ea nostrud sit",
-            "subtitle": "elit",
-            "title": "in"
+            "source": "in qui ",
+            "subtitle": "nisi est ex veniam occaecat",
+            "title": "dolor"
         },
         {
-            "source": "tempor id Ut",
-            "subtitle": "mollit et Excepteur esse dolor",
-            "title": "enim consequat aliquip"
+            "source": "aliqua",
+            "subtitle": "eu nulla laboris Ut incididunt",
+            "title": "magna"
         },
         {
-            "source": "irure",
-            "subtitle": "eiusmod aliqua nulla",
-            "title": "ut"
+            "source": "Ut",
+            "subtitle": "qui",
+            "title": "qui ullam"
         },
         {
-            "source": "Duis dolor",
-            "subtitle": "eu nulla enim dolor ad",
-            "title": "dolore"
+            "source": "vo",
+            "subtitle": "dolore ullamco laborum in et",
+            "title": "non ea aute"
+        }
+    ],
+    "external_system_identifiers": [
+        {
+            "type": "SPIRES",
+            "value": "EXPERIMENT-4"
+        },
+        {
+            "type": "SPIRES",
+            "value": "EXPERIMENT-709363285"
+        },
+        {
+            "type": "SPIRES",
+            "value": "EXPERIMENT-24141492705"
+        },
+        {
+            "type": "SPIRES",
+            "value": "EXPERIMENT-91839"
         }
     ],
     "free_keywords": [
-        "esse",
-        "an",
-        "voluptate laborum pariatur",
-        "aliqua culpa",
-        "velit nisi ea"
+        "aliqua et ea"
     ],
-    "hidden_note": "voluptate",
+    "hidden_note": "esse ea Lo",
     "inspire_categories": [
         {
             "source": "undefined",
-            "term": "Theory-HEP"
+            "term": "Instrumentation"
         },
         {
             "source": "curator",
-            "term": "Experiment-Nucl"
+            "term": "Theory-Nucl"
+        },
+        {
+            "source": "arxiv",
+            "term": "Instrumentation"
+        },
+        {
+            "source": "magpie",
+            "term": "Other"
         }
     ],
-    "legacy_creation_date": "3177-08-10T01:50:42.835Z",
+    "legacy_creation_date": "3686-06-30T13:38:31.721Z",
     "new_record": {
-        "$ref": "http://1W}]o"
+        "$ref": "http://1m!,L)?"
     },
     "other_experiment_names": [
         {
-            "source": "magna deserunt",
-            "subtitle": "esse dolore",
-            "title": "incididunt nisi culpa minim"
+            "source": "occaecat aute nisi laborum in",
+            "subtitle": "ut reprehenderit mollit minim in",
+            "title": "ut cillum commodo labore"
         },
         {
-            "source": "eu aut",
-            "subtitle": "eiusmod cillum aliqua velit",
-            "title": "fugiat elit"
-        },
-        {
-            "source": "aute",
-            "subtitle": "sit",
-            "title": ""
+            "source": "aliquip reprehenderit dolor labore aute",
+            "subtitle": "aliquip Excepteur et labore in",
+            "title": "Lorem ullamco cillum Ut"
         }
     ],
     "public_notes": [
         {
-            "source": "id eu",
-            "value": "mollit consequat aliquip in ut"
+            "source": "amet eiusmod dolor repre",
+            "value": "ex ad"
+        },
+        {
+            "source": "dolor",
+            "value": "incididunt commodo quis ex"
         }
     ],
     "related_experiments": [
         {
             "curated_relation": true,
-            "name": "ad sint",
+            "name": "id",
             "record": {
-                "$ref": "http://1-D4qccJjO_"
+                "$ref": "http://1EQ0\\"
             },
-            "relation": "predecessor"
+            "relation": "successor"
         }
     ],
     "self": {
-        "$ref": "http://1O;uB"
+        "$ref": "http://1:"
     },
     "spokespersons": [
+        {
+            "curated_relation": true,
+            "current": false,
+            "end_date": "dddd-dd-dd",
+            "ids": [
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "q-3000-4753"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "Z-4139-5581"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "c-0769-6871"
+                }
+            ],
+            "name": "aliqua",
+            "record": {
+                "$ref": "http://1%j[8:_r"
+            },
+            "start_date": "dddd-dd-dd"
+        },
         {
             "curated_relation": true,
             "current": true,
             "end_date": "dddd-dd-dd",
             "ids": [
                 {
-                    "schema": "SLAC",
-                    "value": "SLAC-0389163079"
-                },
-                {
-                    "schema": "SLAC",
-                    "value": "SLAC-61"
-                },
-                {
-                    "schema": "SLAC",
-                    "value": "SLAC-8950939557"
-                },
-                {
-                    "schema": "SLAC",
-                    "value": "SLAC-504286945"
-                },
-                {
-                    "schema": "SLAC",
-                    "value": "SLAC-2250647876"
+                    "schema": "RESEARCHERID",
+                    "value": "P-8904-9493"
                 }
             ],
-            "name": "tempor laborum consequat anim est",
+            "name": "officia commodo Ut pariatur reprehenderit",
             "record": {
-                "$ref": "http://1_dcO"
+                "$ref": "http://1"
+            },
+            "start_date": "dddd-dd-dd"
+        },
+        {
+            "curated_relation": true,
+            "current": true,
+            "end_date": "dddd-dd-dd",
+            "ids": [
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "X-7513-1430"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "y-3921-3790"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "Z-0228-9456"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "w-6033-7558"
+                }
+            ],
+            "name": "magna consectetur",
+            "record": {
+                "$ref": "http://1"
             },
             "start_date": "dddd-dd-dd"
         },
         {
             "curated_relation": false,
-            "current": true,
+            "current": false,
             "end_date": "dddd-dd-dd",
             "ids": [
                 {
-                    "schema": "SLAC",
-                    "value": "SLAC-17"
+                    "schema": "RESEARCHERID",
+                    "value": "s-2326-0049"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "k-6005-1256"
+                },
+                {
+                    "schema": "RESEARCHERID",
+                    "value": "x-9469-0268"
                 }
             ],
-            "name": "occaecat",
+            "name": "et consequat mollit deserunt",
             "record": {
-                "$ref": "http://1-4|bt~"
+                "$ref": "http://1XeyMAHJ"
             },
             "start_date": "dddd-dd-dd"
         }
     ],
     "titles": [
         {
-            "source": "Lor",
-            "subtitle": "enim nulla ut",
-            "title": "magna consectetur"
+            "source": "esse sint eiusm",
+            "subtitle": "id elit",
+            "title": "ea quis"
+        },
+        {
+            "source": "sint in dolore",
+            "subtitle": "dolor in",
+            "title": "Lorem non nulla"
         }
     ],
     "urls": [
         {
-            "description": "eu",
-            "value": "http://1-n5qBE(*"
+            "description": "sint",
+            "value": "http://1vW"
         },
         {
-            "description": "cupidatat proident",
-            "value": "http://1Bwp;kuY~L^"
-        },
-        {
-            "description": "anim id amet Duis dolor",
-            "value": "http://1"
-        },
-        {
-            "description": "occaecat deserunt eiusmod non",
-            "value": "http://1Ja~:"
-        },
-        {
-            "description": "laborum proident irure enim",
-            "value": "http://1`KShO!=mTm"
+            "description": "aliquip ipsum non do fugiat",
+            "value": "http://1Y4j9T[2B-,"
         }
     ]
 }

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1,106 +1,160 @@
 {
     "_collections": [
-        "sit dolore sunt dolor",
-        "cillum incididunt"
+        "dolore"
     ],
     "_fft": [
         {
-            "comment": "i",
-            "creation_datetime": "4402-01-02T10:42:33.230Z",
-            "description": "sunt commodo tempor aliquip",
-            "filename": "Excepteur",
+            "comment": "id velit",
+            "creation_datetime": "2329-12-31T20:45:29.837Z",
+            "description": "amet cillum",
+            "filename": "ut laboris ex e",
             "flags": [
-                "ut in pariatur reprehenderit",
-                "mollit eiusmod voluptate"
+                "ea"
             ],
-            "format": "amet ut laborum ",
-            "path": "tempor lab",
-            "status": "cillum",
-            "type": "in sit ea fugiat",
-            "version": 14074083
+            "format": "minim in",
+            "path": "fugiat dolore",
+            "status": "non magna",
+            "type": "nulla consequat qui aliqua officia",
+            "version": -17886091
+        },
+        {
+            "comment": "minim qui in cupidatat",
+            "creation_datetime": "2051-05-09T10:10:04.193Z",
+            "description": "voluptate",
+            "filename": "sit labore velit adipisicing sed",
+            "flags": [
+                "incididunt",
+                "esse",
+                "laborum nisi"
+            ],
+            "format": "quis dolor",
+            "path": "qui amet",
+            "status": "pariatur Duis dolor reprehenderit cupidatat",
+            "type": "in nulla minim nostrud Ut",
+            "version": 62723346
+        },
+        {
+            "comment": "nostrud cillum velit deserunt occaecat",
+            "creation_datetime": "2370-08-13T21:00:23.477Z",
+            "description": "culpa",
+            "filename": "ea Ut dolor",
+            "flags": [
+                "aute",
+                "id occaecat incididunt",
+                "in et",
+                "quis incididunt",
+                "ad reprehenderit"
+            ],
+            "format": "fugiat exercitation",
+            "path": "eiusmod nulla",
+            "status": "sed consequat aliqua sit",
+            "type": "in voluptate mollit",
+            "version": 48371384
+        },
+        {
+            "comment": "sit dolor anim laborum ea",
+            "creation_datetime": "2052-08-08T15:56:30.221Z",
+            "description": "laboris",
+            "filename": "nulla",
+            "flags": [
+                "proident id velit",
+                "Ut iru",
+                "do incididunt dolore Ut mollit",
+                "proident ad",
+                ""
+            ],
+            "format": "ipsum",
+            "path": "irure",
+            "status": "Excepteur anim",
+            "type": "laboris Lo",
+            "version": 29735856
         }
     ],
     "_private_notes": [
         {
-            "source": "sed",
-            "value": "consequat dolor et sed est"
+            "source": "aute",
+            "value": "ad consequat proident commodo"
         },
         {
-            "source": "ullamco",
-            "value": "esse e"
+            "source": "Ut ipsum",
+            "value": "in incididunt reprehenderit"
+        },
+        {
+            "source": "ve",
+            "value": "ea"
         }
     ],
     "abstracts": [
         {
-            "source": "amet dolore",
-            "value": "deserunt commodo elit minim"
+            "source": "aliquip dolore ut magna occaecat",
+            "value": "ipsum"
+        },
+        {
+            "source": "do et",
+            "value": "ea nostrud culpa"
+        },
+        {
+            "source": "reprehenderit ad nulla",
+            "value": "irure ut proident"
         }
     ],
     "accelerator_experiments": [
         {
-            "accelerator": "consectetur Lorem",
+            "accelerator": "aliqua",
             "curated_relation": false,
-            "experiment": "ea ipsum quis",
-            "institution": "labore velit in",
-            "legacy_name": "in qui officia",
+            "experiment": "quis nulla qui reprehenderit non",
+            "institution": "in fugiat magna tempor",
+            "legacy_name": "mollit",
             "record": {
-                "$ref": "http://1j'WWik~2Uk"
-            }
-        },
-        {
-            "accelerator": "do in Ut id reprehenderit",
-            "curated_relation": true,
-            "experiment": "aliqua qui nisi",
-            "institution": "magna",
-            "legacy_name": "officia est",
-            "record": {
-                "$ref": "http://1C"
-            }
-        },
-        {
-            "accelerator": "nisi enim",
-            "curated_relation": true,
-            "experiment": "enim dolor officia fugiat ullamco",
-            "institution": "nulla laborum",
-            "legacy_name": "fugiat amet veniam culpa",
-            "record": {
-                "$ref": "http://1\\GMClQ8"
+                "$ref": "http://10h"
             }
         }
     ],
     "acquisition_source": {
-        "date": "amet labore fugiat minim",
-        "email": "5-XqM7-5@JQToTUYCxTzDIRSlY.zz",
-        "internal_uid": 41970312,
-        "method": "hepcrawl",
-        "orcid": "1962-1600-2521-8142",
-        "source": "cillum",
-        "submission_number": "non Lorem exercitation adipisicing in"
+        "date": "deserunt cupidatat",
+        "email": "5GEmfDr@JwkkEhbUmlJcSMxrIZzyvRhUOH.jgx",
+        "internal_uid": -32550518,
+        "method": "batchuploader",
+        "orcid": "5331-6809-6724-4024",
+        "source": "ad",
+        "submission_number": "fugi"
     },
     "arxiv_eprints": [
         {
             "categories": [
-                "physics.hist-ph",
-                "stat.ME"
+                "physics.comp-ph",
+                "q-fin.ST",
+                "q-bio.TO",
+                "physics.soc-ph",
+                "cs.MM"
             ],
-            "value": "4818>42537"
+            "value": "1665x74991"
         },
         {
             "categories": [
-                "math",
-                "math.IT"
+                "physics.pop-ph",
+                "q-bio.QM",
+                "q-bio.CB",
+                "physics.ins-det",
+                "math.DG"
             ],
-            "value": "5744=8669"
+            "value": "0911L73725"
         },
         {
             "categories": [
-                "math.GT",
-                "cs.DM",
-                "math.AP",
-                "cs.SI",
-                "physics.geo-ph"
+                "cs.HC",
+                "physics.chem-ph",
+                "q-fin.PM",
+                "q-bio.PE"
             ],
-            "value": "7104H6929"
+            "value": "_/62201665286"
+        },
+        {
+            "categories": [
+                "cs.NI",
+                "q-fin.GN"
+            ],
+            "value": "WHs/1204"
         }
     ],
     "authors": [
@@ -109,306 +163,211 @@
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1IO=g:a"
+                        "$ref": "http://1~h].!L'-s%"
                     },
-                    "value": "ullamco nulla dolor"
+                    "value": "Lorem nulla"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1:zM~pERkEk"
+                    },
+                    "value": "ea Duis"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://17oy/"
+                    },
+                    "value": "proident sunt incididunt consectetur est"
                 }
             ],
             "alternative_names": [
-                "do esse in laboris",
-                "laboris dolore anim culpa ",
-                "dolore",
-                "culpa Lorem "
+                "incididunt nisi ",
+                "consequat velit occaecat ipsum",
+                "aliquip nostrud minim amet"
             ],
             "credit_roles": [
-                "Resources",
+                "Writing - review & editing",
+                "Supervision",
+                "Project administration",
                 "Methodology"
             ],
             "curated_relation": false,
             "emails": [
-                "4cblf2yC9HmUf@uMxpNHXbcTULttefWCdQ.wjau"
+                "7I9PZgcMq@uIBVgsTuhAhEffguXnmf.kcrd",
+                "54gf@uBbkmCSoLjqsCpMBsQhnOEEaV.ejsz",
+                "bL6wFbc@nB.gbp",
+                "1IknzSjLGVezHLN@OnAltViDQQHYcqcooIGWJzrzXnSoW.zfw",
+                "NVsZ@B.huun"
             ],
-            "full_name": "et do in ea",
+            "full_name": "pariatur in id ulla",
             "ids": [
                 {
-                    "schema": "JACOW",
-                    "value": "JACoW-23017002"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-10061077"
                 },
                 {
-                    "schema": "JACOW",
-                    "value": "JACoW-95882493"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-44886683"
                 },
                 {
-                    "schema": "JACOW",
-                    "value": "JACoW-43330846"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-12387985"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-78976983"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-77413424"
                 }
             ],
             "inspire_roles": [
+                "editor",
                 "supervisor",
-                "supervisor"
+                "author",
+                "author",
+                "author"
             ],
             "raw_affiliations": [
                 {
-                    "source": "in nisi",
-                    "value": "ex"
+                    "source": "aliqua voluptate",
+                    "value": "sit"
                 },
                 {
-                    "source": "minim",
-                    "value": "elit dolore qui laboris minim"
+                    "source": "dolor pariatur ut",
+                    "value": "deserunt consectetur exercitation"
                 },
                 {
-                    "source": "laboris mollit",
-                    "value": "magna min"
+                    "source": "veniam reprehenderit ea",
+                    "value": "aute in in"
                 },
                 {
-                    "source": "ut consectetur incididunt in",
-                    "value": "aliquip nulla irure et sed"
-                },
-                {
-                    "source": "in adipisicing",
-                    "value": "cillum"
+                    "source": "sed tempor Excepteur ex",
+                    "value": "ullamco elit ad dolor"
                 }
             ],
             "record": {
-                "$ref": "http://1"
+                "$ref": "http://1^KKFWp"
             },
-            "uuid": "b58be549-be33-0389-24f4-b493f138b380"
+            "uuid": "a9937e47-bbb9-48ea-1afb-01cea10dd9d5"
         },
         {
             "affiliations": [
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1"
+                        "$ref": "http://1NCvHn]"
                     },
-                    "value": "veniam Lorem ipsum laborum nulla"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1P(`{"
-                    },
-                    "value": "elit reprehenderit ex sint"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1EV"
-                    },
-                    "value": "consequat eu id in eiusmod"
+                    "value": "do "
                 },
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1]R\";"
+                        "$ref": "http://1S~2Yr@"
                     },
-                    "value": "pariatur laborum"
+                    "value": "dolor"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1?%c"
+                    },
+                    "value": "id est"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1c$"
+                    },
+                    "value": "ex sint do ut"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1n&n,IcF["
+                    },
+                    "value": "in deserunt"
                 }
             ],
             "alternative_names": [
-                "anim nulla et",
-                "pariatur aute ut adipisicing",
-                "ut",
-                "do anim aute",
-                "et"
+                "enim dolor mollit",
+                "in ex consectetur",
+                "Ut commodo dolore consectetur ex"
             ],
             "credit_roles": [
-                "Resources",
-                "Project administration",
-                "Supervision",
-                "Resources",
-                "Supervision"
+                "Writing - original draft",
+                "Validation",
+                "Writing - original draft",
+                "Writing - original draft",
+                "Software"
             ],
             "curated_relation": false,
             "emails": [
-                "IWC4kGY@AQx.clgf",
-                "6Zgu@SGYQQZmVu.jbua",
-                "LYNaAiGG0E@qZuIOoJOfsaMQOmmhDCeqPt.oof",
-                "AZBKFd3OOR@yWxLldcqrfw.tx",
-                "Jtcvp4CEK@BYVAW.yzr"
+                "p6EywBzOpRIB@eaGDPcOEcxkatFp.py",
+                "CupPyxDv@odICXygzKcvJgLBKqw.rlvj",
+                "V5cvV-m0-m-K-e@Gs.eb"
             ],
-            "full_name": "ex est",
+            "full_name": "laboris dolor Excepteur",
             "ids": [
                 {
-                    "schema": "JACOW",
-                    "value": "JACoW-26763595"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-62979039"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-00276119"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-81743189"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-64401026"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-58663474"
                 }
             ],
             "inspire_roles": [
                 "editor",
-                "supervisor",
                 "author",
-                "editor"
+                "author",
+                "author"
             ],
             "raw_affiliations": [
                 {
-                    "source": "reprehenderit qui Lorem voluptate sunt",
-                    "value": "incididunt reprehenderit ut"
-                },
-                {
-                    "source": "ex",
-                    "value": "irure eu Excepteur"
-                },
-                {
-                    "source": "Lorem reprehenderit dolor mollit ipsum",
-                    "value": "ipsum et sint in"
+                    "source": "n",
+                    "value": "aliquip adipisicing"
                 }
             ],
             "record": {
-                "$ref": "http://1`R4MDTUR!"
+                "$ref": "http://10XBcU"
             },
-            "uuid": "8dab9d0d-11e6-c924-0436-22be3108204a"
+            "uuid": "81c54df7-79ef-c3a1-37d6-8ab8d3cec3c4"
         },
         {
             "affiliations": [
                 {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1TJor"
-                    },
-                    "value": "incididunt in"
-                },
-                {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1'q%yirO'L-"
+                        "$ref": "http://13;o."
                     },
-                    "value": "amet elit aliqua dolore"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1&%#|"
-                    },
-                    "value": "laboris"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1p~R"
-                    },
-                    "value": "dolore deserunt"
+                    "value": "Lorem"
                 }
             ],
             "alternative_names": [
-                "pariatur culpa officia reprehenderit",
-                "Duis",
-                "ut sit"
+                "minim mollit proident",
+                "et"
             ],
             "credit_roles": [
                 "Funding acquisition",
-                "Software",
-                "Project administration",
-                "Visualization"
+                "Investigation",
+                "Methodology",
+                "Writing - original draft",
+                "Conceptualization"
             ],
-            "curated_relation": true,
+            "curated_relation": false,
             "emails": [
-                "34cqv@SEXGHGTKhxlSdqoaz.zu",
-                "yv1A5mmiLbTfyAL@aTIEutxHnnqeKbEQKMRBzFLZyHsmrpOi.xcl",
-                "HnOp@k.yb"
+                "S3ck3wZP@CV.ep"
             ],
-            "full_name": "aliqua veniam tempor occaecat",
+            "full_name": "fugiat qui id veniam",
             "ids": [
                 {
-                    "schema": "JACOW",
-                    "value": "JACoW-49879786"
-                }
-            ],
-            "inspire_roles": [
-                "author",
-                "editor",
-                "supervisor",
-                "editor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "Lo",
-                    "value": "nisi dolor tempor aliqua veniam"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-88986786"
                 },
                 {
-                    "source": "sunt",
-                    "value": "adipisicing dolor mollit nostrud"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-34805296"
                 },
                 {
-                    "source": "veniam irure magna U",
-                    "value": "sed commodo reprehenderit"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-92511360"
                 },
                 {
-                    "source": "cons",
-                    "value": "est do"
-                },
-                {
-                    "source": "dolor mollit",
-                    "value": "nulla nostrud"
-                }
-            ],
-            "record": {
-                "$ref": "http://1"
-            },
-            "uuid": "9bfd1b6c-7ce0-75ad-cf23-f54eae53c500"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1[:"
-                    },
-                    "value": "ullamco id"
-                }
-            ],
-            "alternative_names": [
-                "proident Ut enim",
-                "mollit officia"
-            ],
-            "credit_roles": [
-                "Visualization"
-            ],
-            "curated_relation": true,
-            "emails": [
-                "Xkji5pAOKb9@kWHpMxoXBapYlQnsKrjFkvRnG.ayu",
-                "2E801pU@qXnCNhWJaK.uqnz",
-                "W-izX1lWFI@Izl.bbzj",
-                "V6vNRETkh6LwM@uBBPbXmSzxLMDlDEBbbCsG.jqmw",
-                "chn1E55IZ1@nbvPXBJTfxQ.blcx"
-            ],
-            "full_name": "nisi",
-            "ids": [
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-39794597"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-94298262"
-                },
-                {
-                    "schema": "JACOW",
-                    "value": "JACoW-38566051"
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-64832675"
                 }
             ],
             "inspire_roles": [
@@ -416,371 +375,419 @@
             ],
             "raw_affiliations": [
                 {
-                    "source": "ea occaecat aliqua ad incididunt",
-                    "value": "amet proident ea"
-                },
-                {
-                    "source": "deserun",
-                    "value": "tempor "
-                },
-                {
-                    "source": "deserunt labore dolor velit id",
-                    "value": "consequat reprehenderit nulla in"
+                    "source": "magna deserunt sed con",
+                    "value": "ipsum voluptate ullamco"
                 }
             ],
             "record": {
-                "$ref": "http://1S3l0h"
+                "$ref": "http://1HT}.Z'X"
             },
-            "uuid": "99804363-4927-52d6-1e1d-68f149f90d8f"
+            "uuid": "067cfdc7-11df-df18-fa3b-d877e455037b"
         }
     ],
     "book_series": [
         {
-            "title": "anim",
-            "volume": "exercitation voluptate dolore cupid"
-        },
-        {
-            "title": "amet id commodo veniam labore",
-            "volume": "Ut"
-        },
-        {
-            "title": "id ullamco magna consequat esse",
-            "volume": "occaecat Excepteur"
+            "title": "ad",
+            "volume": "dolor et dolore amet irure"
         }
     ],
-    "citeable": true,
+    "citeable": false,
     "collaborations": [
         {
             "record": {
-                "$ref": "http://1E"
+                "$ref": "http://1cj"
             },
-            "value": "magna cillum"
-        },
-        {
-            "record": {
-                "$ref": "http://1f'pn"
-            },
-            "value": "commodo Ut consectetur"
+            "value": "sunt sed"
         }
     ],
-    "control_number": 73760528,
+    "control_number": -82468670,
     "copyright": [
         {
-            "holder": "dolore Duis incididunt eiusmod",
-            "material": "reprint",
-            "statement": "consequat nostrud",
-            "url": "http://1Xkl1$hIv="
-        },
-        {
-            "holder": "cillum enim aliqua",
+            "holder": "est do aliqua in",
             "material": "preprint",
-            "statement": "magna culpa in Lorem",
-            "url": "http://1\"b$)%Ye"
+            "statement": "ipsum",
+            "url": "http://1>}&2"
         },
         {
-            "holder": "eiusmod in dolore",
-            "material": "reprint",
-            "statement": "dolore dolor ex tempor elit",
-            "url": "http://1]?3^]<N"
+            "holder": "culpa in elit consequat",
+            "material": "preprint",
+            "statement": "en",
+            "url": "http://1C\""
         },
         {
-            "holder": "pariatur ex nostrud",
-            "material": "reprint",
-            "statement": "ex enim proident magna dolore",
-            "url": "http://1pQa0+nn"
-        },
-        {
-            "holder": "in",
-            "material": "erratum",
-            "statement": "exercitation sed non",
-            "url": "http://1IpR$ByP\\{"
+            "holder": "sint Excepteur",
+            "material": "preprint",
+            "statement": "laborum nulla Excepteur",
+            "url": "http://1.qG&7[/6M"
         }
     ],
     "core": false,
     "corporate_author": [
-        "nisi Ut ad voluptate nostrud",
-        "exe",
-        "dolore aliquip sed dolor",
-        "adipisicing aute ut commodo labore"
+        "nisi offic",
+        "adip"
     ],
-    "deleted": true,
+    "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1<"
+            "$ref": "http://1o"
         },
         {
-            "$ref": "http://1|Xh6}]5 ]"
+            "$ref": "http://1rcz)/$7yY~"
         },
         {
-            "$ref": "http://1LKb#Go"
-        },
-        {
-            "$ref": "http://1vz"
+            "$ref": "http://1"
         }
     ],
     "document_type": [
         "proceedings",
-        "article",
-        "thesis"
+        "book"
     ],
     "dois": [
         {
             "material": "addendum",
-            "source": "laborum",
-            "value": "10.208537.9195/@zd`T"
+            "source": "reprehenderi",
+            "value": "10.5504052276.22470/FY\"2"
+        },
+        {
+            "material": "reprint",
+            "source": "nisi",
+            "value": "10.3/47D"
         }
     ],
     "edition": [
         {
-            "edition": "Excepteur consequat dolor"
+            "edition": "reprehenderit dolor et exercitation"
         },
         {
-            "edition": "Duis quis nostrud"
+            "edition": "sunt sint"
         },
         {
-            "edition": "dolore esse al"
+            "edition": "in Ut"
         },
         {
-            "edition": "commodo"
+            "edition": "ut non do eiusmod"
+        },
+        {
+            "edition": "qui in magna"
         }
     ],
     "energy_ranges": [
-        5086700,
-        66219648,
-        12204664,
-        59537003,
-        40023591
+        12974339,
+        75176819,
+        64013831
     ],
     "external_system_identifiers": [
         {
-            "schema": "sed dolore anim Excepteur",
-            "value": "dolor occaecat eu ipsum nisi"
+            "schema": "aliqua aliquip aute",
+            "value": "cillum mollit magna adipisicing"
+        },
+        {
+            "schema": "in proident",
+            "value": "non"
         }
     ],
     "funding_info": [
         {
-            "agency": "dolore",
-            "grant_number": "dolor Ut ad aliquip eu",
-            "project_number": "reprehenderit id Ut laboris in"
+            "agency": "qui",
+            "grant_number": "consequat proident ",
+            "project_number": "dolor"
         },
         {
-            "agency": "fugiat",
-            "grant_number": "labore",
-            "project_number": "ad reprehenderit ex aliquip"
+            "agency": "eiusmod deser",
+            "grant_number": "ut amet nisi",
+            "project_number": "aliquip"
         },
         {
-            "agency": "Excepteur sunt dolor adipisicing",
-            "grant_number": "consequat",
-            "project_number": "eu dolore"
+            "agency": "quis",
+            "grant_number": "deserunt",
+            "project_number": "ut ut"
         }
     ],
     "imprints": [
         {
             "date": "dddd-dd-dd",
-            "place": "quis nisi exercitation eiusmod",
-            "publisher": "aute"
+            "place": "et",
+            "publisher": "culpa"
         },
         {
             "date": "dddd-dd-dd",
-            "place": "ullamco ex",
-            "publisher": "mollit magna aliqua"
+            "place": "veniam voluptate consectetur ea dolore",
+            "publisher": "minim sunt ea aliquip dolor"
         },
         {
             "date": "dddd-dd-dd",
-            "place": "Lorem do in id pariatur",
-            "publisher": "elit est"
-        },
-        {
-            "date": "dddd-dd-dd",
-            "place": "reprehenderit",
-            "publisher": "ut ex tempor velit"
-        },
-        {
-            "date": "dddd-dd-dd",
-            "place": "fugiat dolor exercitation esse in",
-            "publisher": "pariatur velit Excepteur"
+            "place": "nisi ea",
+            "publisher": "dolore"
         }
     ],
     "inspire_categories": [
         {
-            "source": "user",
-            "term": "Other"
-        },
-        {
-            "source": "arxiv",
-            "term": "Experiment-HEP"
+            "source": "undefined",
+            "term": "Accelerators"
         },
         {
             "source": "undefined",
-            "term": "Experiment-HEP"
+            "term": "Data Analysis and Statistics"
+        },
+        {
+            "source": "curator",
+            "term": "Accelerators"
         }
     ],
     "isbns": [
         {
-            "medium": "print",
-            "value": "311208"
+            "medium": "hardcover",
+            "value": "61"
         },
         {
-            "medium": "softcover",
-            "value": "6603658"
+            "medium": "online",
+            "value": "9666635"
+        },
+        {
+            "medium": "hardcover",
+            "value": "6943186"
         }
     ],
     "keywords": [
         {
-            "schema": "PDG",
-            "source": "in ut ut aliquip ex",
-            "value": "ex veniam"
-        },
-        {
-            "schema": "PACS",
-            "source": "consectetur dolore adipisicing",
-            "value": "id"
-        },
-        {
-            "schema": "INSPIRE",
-            "source": "velit re",
-            "value": "deserunt"
-        },
-        {
-            "schema": "PACS",
-            "source": "adipisicing non nisi",
-            "value": "quis cupidatat do in"
+            "schema": "JACOW",
+            "source": "eiusmod elit cupidatat dolor",
+            "value": "in"
         },
         {
             "schema": "JACOW",
-            "source": "sed qui laboris",
-            "value": "consectetur"
+            "source": "Ut cillum officia Lorem",
+            "value": "do dolore Lorem"
+        },
+        {
+            "schema": "PACS",
+            "source": "culpa",
+            "value": "id irure"
+        },
+        {
+            "schema": "PACS",
+            "source": "aute sunt est",
+            "value": "sit sed aliqua Duis"
+        },
+        {
+            "schema": "PDG",
+            "source": "veniam incididunt",
+            "value": "adipisicing qui dolore nisi"
         }
     ],
     "languages": [
-        "2Y"
+        "mw",
+        "wH"
     ],
-    "legacy_creation_date": "2379-03-16T20:20:46.098Z",
+    "legacy_creation_date": "2741-02-21T03:19:23.287Z",
     "license": [
         {
-            "imposing": "anim adipisicing officia",
-            "license": "i",
-            "material": "preprint",
-            "url": "http://1:sv]:JLdmi"
+            "imposing": "officia in Excepteur",
+            "license": "do aliqua dolore",
+            "material": "publication",
+            "url": "http://1.;K"
         },
         {
-            "imposing": "officia elit amet",
-            "license": "voluptate culpa",
-            "material": "reprint",
-            "url": "http://1"
+            "imposing": "dolor nulla veniam occaecat dolore",
+            "license": "non commodo irure",
+            "material": "erratum",
+            "url": "http://1vz o[Yt #"
         },
         {
-            "imposing": "consectetur",
-            "license": "pariatur",
-            "material": "reprint",
-            "url": "http://1/"
-        },
-        {
-            "imposing": "minim officia magna qui velit",
-            "license": "incididunt ullamco esse sed",
-            "material": "addendum",
-            "url": "http://1;?kt"
+            "imposing": "deserunt ad in qui",
+            "license": "fugiat dolore sed aliqua",
+            "material": "publication",
+            "url": "http://1;uN"
         }
     ],
     "new_record": {
         "$ref": "http://1"
     },
-    "number_of_pages": 98486796,
+    "number_of_pages": 94623436,
     "persistent_identifiers": [
         {
-            "material": "preprint",
+            "material": "publication",
             "schema": "URN",
-            "source": "sint ipsum labore cillum in",
-            "value": "consequat ut Ut"
+            "source": "sed reprehenderit aliquip",
+            "value": "dolor"
+        },
+        {
+            "material": "preprint",
+            "schema": "HDL",
+            "source": "fugiat sed qui Lorem",
+            "value": "mollit aute eiusmod exercitation incididunt"
+        },
+        {
+            "material": "publication",
+            "schema": "HDL",
+            "source": "exercitation mollit aute",
+            "value": "pariatur dolor commodo id"
         },
         {
             "material": "addendum",
             "schema": "URN",
-            "source": "minim",
-            "value": "Excepteur ut fugiat incididunt"
+            "source": "exercitation laboris Duis officia",
+            "value": "sunt"
         },
         {
-            "material": "erratum",
+            "material": "preprint",
             "schema": "HDL",
-            "source": "exercitation adipisicing",
-            "value": "aliqua qui"
-        },
-        {
-            "material": "erratum",
-            "schema": "URN",
-            "source": "in",
-            "value": "ipsum"
+            "source": "mollit nulla reprehenderit",
+            "value": "exercitation"
         }
     ],
     "preprint_date": "dddd-dd-dd",
     "public_notes": [
         {
-            "source": "deserunt repr",
-            "value": ""
+            "source": "ad occaecat",
+            "value": "commodo in"
         },
         {
-            "source": "reprehender",
-            "value": "mollit proident in laboris officia"
+            "source": "reprehenderit nulla id Excepteur ut",
+            "value": "dolor nulla magna ut dolore"
+        },
+        {
+            "source": "in est sed",
+            "value": "id"
         }
     ],
     "publication_info": [
         {
-            "artid": "sint ea",
-            "cnum": "C01-10-52",
-            "conf_acronym": "sint dolor",
+            "artid": "exercitation",
+            "cnum": "C66-84-33",
+            "conf_acronym": "quis minim aliqua esse laborum",
             "conference_record": {
-                "$ref": "http://1"
+                "$ref": "http://1A/;j<"
             },
-            "confpaper_info": "sed non",
-            "curated_relation": false,
-            "journal_issue": "anim quis",
+            "confpaper_info": "incididunt labore esse cupid",
+            "curated_relation": true,
+            "journal_issue": "amet in cillum anim in",
             "journal_record": {
-                "$ref": "http://1Q<pNn$0 b"
+                "$ref": "http://17J]t7}d"
             },
-            "journal_title": "c",
-            "journal_volume": "commodo",
-            "material": "publication",
-            "page_end": "Lorem",
-            "page_start": "dolor sit",
-            "parent_isbn": "674365460X",
+            "journal_title": "voluptate in ad dolore",
+            "journal_volume": "irur",
+            "material": "reprint",
+            "page_end": "cillum",
+            "page_start": "ullamco c",
+            "parent_isbn": "978252395675X",
             "parent_record": {
-                "$ref": "http://1q:HF`i8_K7"
+                "$ref": "http://1ZnqI:7P"
             },
-            "parent_report_number": "pariatur commodo exercitation voluptate",
-            "pubinfo_freetext": "aliqua exercitation dolor",
-            "year": 1178
+            "parent_report_number": "eiusmod fugiat anim velit",
+            "pubinfo_freetext": "consectetur reprehenderit ipsum tempor quis",
+            "year": 1085
         },
         {
-            "artid": "cillum quis adipisicing",
-            "cnum": "C82-37-89.8807352696",
-            "conf_acronym": "enim laboris amet deserunt pariatur",
+            "artid": "cupidatat nisi",
+            "cnum": "C29-62-47",
+            "conf_acronym": "aliquip dolore",
             "conference_record": {
-                "$ref": "http://1~_fln"
+                "$ref": "http://15UMhdT"
             },
-            "confpaper_info": "cillum",
+            "confpaper_info": "magna ad tempor sunt",
             "curated_relation": false,
-            "journal_issue": "consequat eu dolore ad nisi",
+            "journal_issue": "consectetur eiusmod deserunt cu",
             "journal_record": {
-                "$ref": "http://1/'?\"Psse"
+                "$ref": "http://1rqc924}'W"
             },
-            "journal_title": "occaecat",
-            "journal_volume": "elit eiusmod",
-            "material": "addendum",
-            "page_end": "occaecat labore et",
-            "page_start": "voluptate nulla ullamco",
-            "parent_isbn": "085594384X",
+            "journal_title": "do laboris eiusmod irure",
+            "journal_volume": "pariatur e",
+            "material": "publication",
+            "page_end": "ullamco",
+            "page_start": "sunt dolore ea dolore",
+            "parent_isbn": "1020348990",
             "parent_record": {
-                "$ref": "http://1acm4FI5^^"
+                "$ref": "http://1b"
             },
-            "parent_report_number": "ea",
-            "pubinfo_freetext": "Excepteur culpa ad",
-            "year": 1243
+            "parent_report_number": "ut fugiat ex veniam",
+            "pubinfo_freetext": "nisi anim",
+            "year": 1431
+        },
+        {
+            "artid": "occaecat",
+            "cnum": "C67-53-42.08563",
+            "conf_acronym": "in Lorem labore irure qui",
+            "conference_record": {
+                "$ref": "http://1rx-ty"
+            },
+            "confpaper_info": "eu",
+            "curated_relation": false,
+            "journal_issue": "veniam eiusmod in amet consectetur",
+            "journal_record": {
+                "$ref": "http://1m"
+            },
+            "journal_title": "dolor tempor irure",
+            "journal_volume": "culpa elit incididunt qui",
+            "material": "erratum",
+            "page_end": "minim sit irure",
+            "page_start": "est ",
+            "parent_isbn": "554276363X",
+            "parent_record": {
+                "$ref": "http://1Lt*4"
+            },
+            "parent_report_number": "id ut",
+            "pubinfo_freetext": "dolor aliqua Ut consequat",
+            "year": 1288
+        },
+        {
+            "artid": "dolor amet eiusmod",
+            "cnum": "C25-86-26",
+            "conf_acronym": "incididunt Duis dolore",
+            "conference_record": {
+                "$ref": "http://1_iBr(<^"
+            },
+            "confpaper_info": "dolore nulla",
+            "curated_relation": false,
+            "journal_issue": "culpa",
+            "journal_record": {
+                "$ref": "http://1E"
+            },
+            "journal_title": "est fugiat ut",
+            "journal_volume": "ex nisi minim labo",
+            "material": "publication",
+            "page_end": "labore Ut",
+            "page_start": "ea cupidatat amet et",
+            "parent_isbn": "377192021X",
+            "parent_record": {
+                "$ref": "http://10kmZS/Lx"
+            },
+            "parent_report_number": "dolor eiusmod dolore",
+            "pubinfo_freetext": "laborum enim elit pariatur",
+            "year": 1456
+        },
+        {
+            "artid": "ea sed cillum nulla sint",
+            "cnum": "C83-75-74",
+            "conf_acronym": "esse est aliqua",
+            "conference_record": {
+                "$ref": "http://1b`F?[y4z"
+            },
+            "confpaper_info": "dolor",
+            "curated_relation": false,
+            "journal_issue": "anim officia pariatur ut",
+            "journal_record": {
+                "$ref": "http://1=jQQ6"
+            },
+            "journal_title": "elit officia minim",
+            "journal_volume": "aliqua minim irure sunt",
+            "material": "erratum",
+            "page_end": "exercitation",
+            "page_start": "esse",
+            "parent_isbn": "979362527486X",
+            "parent_record": {
+                "$ref": "http://1&%a"
+            },
+            "parent_report_number": "nisi",
+            "pubinfo_freetext": "non velit",
+            "year": 1415
         }
     ],
     "publication_type": [
         "lectures",
-        "review",
-        "review"
+        "lectures",
+        "introductory",
+        "lectures"
     ],
     "refereed": true,
     "references": [
@@ -788,365 +795,233 @@
             "curated_relation": false,
             "raw_refs": [
                 {
-                    "position": "Duis nisi Lorem elit officia",
-                    "schema": "eu laboris adipisicing",
-                    "source": "sunt",
-                    "value": "officia elit est sit voluptate"
+                    "position": "magna officia",
+                    "schema": "voluptate",
+                    "source": "magna ullamco dolo",
+                    "value": "dolore"
                 },
                 {
-                    "position": "et magna",
-                    "schema": "proident esse laboris eiusmod magna",
-                    "source": "Ut",
-                    "value": "officia dolore"
-                },
-                {
-                    "position": "ipsum consectetur sunt do",
-                    "schema": "Lorem",
-                    "source": "nostrud",
-                    "value": "fugiat aute sunt in ea"
+                    "position": "est",
+                    "schema": "Ut dolore laboris incididunt veniam",
+                    "source": "velit incididunt magna Lorem enim",
+                    "value": "labore et qui"
                 }
             ],
             "record": {
-                "$ref": "http://1>>(`X"
+                "$ref": "http://1yndUH,#egY"
             },
             "reference": {
                 "arxiv_eprints": [
-                    "mMKB2cTpbA/4860283",
-                    "2193>20239",
-                    "cSgR-Qv/3794057642",
-                    "pN-m_cD1285kQX/4078822785",
-                    "8921B7873"
+                    "8171\"26559",
+                    "TDCkVL356-NMQ/7",
+                    "5Q0N98H5-0/262731214",
+                    "5108j27460"
                 ],
                 "authors": [
                     {
-                        "full_name": "dolor",
-                        "role": "consequat"
-                    },
-                    {
-                        "full_name": "dolore minim",
-                        "role": "ut"
+                        "full_name": "labore do culpa deserunt voluptate",
+                        "role": "sed ullamco"
                     },
                     {
                         "full_name": "sint",
-                        "role": "exercitation laboris est deserunt occaecat"
-                    },
-                    {
-                        "full_name": "amet nulla ut laborum",
-                        "role": "in aliquip ipsum"
+                        "role": "ea reprehenderit exercitation"
                     }
                 ],
                 "book_series": {
-                    "title": "ut",
-                    "volume": "Duis tempor"
+                    "title": "exercitation in aliquip pariatur",
+                    "volume": "nostrud eiusmod"
                 },
                 "collaboration": [
-                    "Ut laborum",
-                    "consecte",
-                    "dolor ad deserunt sunt Lorem",
-                    "ea incididunt"
+                    "aliqua sint consequat et quis",
+                    "sint",
+                    "deserunt in esse adipisicing",
+                    "consequat",
+                    "dolor"
                 ],
                 "dois": [
-                    "10.7051.31/Sp?o@j",
-                    "10.0.18576/mw%;",
-                    "10.762455.1383/y{"
+                    "10.2642699.0876/>DFi[NZ%",
+                    "10.8.385043/u?I!54/x",
+                    "10.5.07255/RA:",
+                    "10.093641.6246/JO_=Sf",
+                    "10.898372.82233661/7gZ`Qa6"
                 ],
                 "imprint": {
                     "date": "dddd-dd-dd",
-                    "place": "Ut",
-                    "publisher": "ut cillum incididunt mollit"
+                    "place": "reprehenderit consectetur",
+                    "publisher": "velit sint id dolore in"
                 },
                 "misc": [
-                    "incididunt et nostrud consectetur magna",
-                    "incididunt esse consequat eu minim",
-                    "consectetur"
+                    "veniam proident velit occaecat",
+                    "nostrud culpa"
                 ],
-                "number": -17209500,
+                "number": -60442879,
                 "persistent_identifiers": [
-                    "nostrud ea Excepteur",
-                    "incididunt officia irure",
-                    "incididunt voluptate",
-                    "adipisicing sint"
+                    "aliquip pariatur Ut labore do",
+                    "nulla"
                 ],
                 "publication_info": {
-                    "artid": "occaecat laboris do anim",
-                    "cnum": "minim laborum sun",
-                    "isbn": "pariatur do commodo mollit",
-                    "journal_issue": "esse voluptate nulla ullamco",
-                    "journal_title": "Lorem amet",
-                    "journal_volume": "cupidatat enim elit",
-                    "page_end": "ex et velit pariatur aliqua",
-                    "page_start": "in anim et tempor est",
-                    "reportnumber": "sunt tempor in",
-                    "year": 1584
+                    "artid": "magna aliquip pariatur",
+                    "cnum": "Ut",
+                    "isbn": "enim sunt voluptate esse deserunt",
+                    "journal_issue": "mollit enim",
+                    "journal_title": "ullamco",
+                    "journal_volume": "mollit ut aliqua sit",
+                    "page_end": "ipsum voluptate sed",
+                    "page_start": "veniam Excepteur elit dolore",
+                    "reportnumber": "eiusmod",
+                    "year": 1312
                 },
-                "texkey": "nostrud dolor",
+                "texkey": "nostrud aliquip ullamco",
                 "titles": [
                     {
-                        "source": "mollit minim dolore",
-                        "subtitle": "pariatur aliquip ad",
-                        "title": "ut officia"
+                        "source": "consequat mollit ipsum magna esse",
+                        "subtitle": "adipisicing nostrud",
+                        "title": "ut non ea deserunt"
                     },
                     {
-                        "source": "fugiat velit mollit aute sint",
-                        "subtitle": "tempor fugiat nulla ut qui",
-                        "title": "est aliqua minim"
+                        "source": "veniam id",
+                        "subtitle": "in laborum quis",
+                        "title": "ea irure in"
                     },
                     {
-                        "source": "sed reprehenderit nisi esse",
-                        "subtitle": "occaecat pariatur id",
-                        "title": "ut exercitation irure"
+                        "source": "tempor qui",
+                        "subtitle": "ad",
+                        "title": "sunt dolor Excepteur"
                     },
                     {
-                        "source": "tempor id",
-                        "subtitle": "exercitatio",
-                        "title": "dolor laborum exercitation"
-                    },
-                    {
-                        "source": "qui",
-                        "subtitle": "veniam",
-                        "title": "ad cillum"
+                        "source": "esse sed ut labore aute",
+                        "subtitle": "sit",
+                        "title": "consectetur"
                     }
                 ],
                 "urls": [
                     {
-                        "description": "voluptate",
-                        "value": "http://1&m"
+                        "description": "dolore elit ",
+                        "value": "http://1U5b'I8u"
+                    },
+                    {
+                        "description": "aliqua laboris cillum Duis esse",
+                        "value": "http://1:O"
                     }
                 ]
             }
         },
         {
-            "curated_relation": true,
+            "curated_relation": false,
             "raw_refs": [
                 {
-                    "position": "ad Ut",
-                    "schema": "id",
-                    "source": "Duis enim voluptate",
-                    "value": "mollit voluptate elit nulla"
-                },
-                {
-                    "position": "nostrud id magna ut",
-                    "schema": "ut commodo dolore dolor",
-                    "source": "reprehenderit aliquip conse",
-                    "value": "nisi fugiat sunt eiusmod minim"
-                },
-                {
-                    "position": "Excepteur esse ut",
-                    "schema": "Duis sit reprehenderit exercitation dese",
-                    "source": "officia",
-                    "value": "Duis ex ad mollit nisi"
-                },
-                {
-                    "position": "pariatur sed nul",
-                    "schema": "sunt incididunt",
-                    "source": "nisi officia eu nulla",
-                    "value": "irure aliqua ut qui"
+                    "position": "labore Duis in",
+                    "schema": "ad labore",
+                    "source": "culpa Lorem magna minim ullamco",
+                    "value": "enim fugiat"
                 }
             ],
             "record": {
-                "$ref": "http://1ch'"
+                "$ref": "http://1zd"
             },
             "reference": {
                 "arxiv_eprints": [
-                    "NXR0j-vBG/8"
+                    "0411'9968",
+                    "QEsnFM5Pr/009",
+                    "bY/3399029",
+                    "9477/3447"
                 ],
                 "authors": [
                     {
-                        "full_name": "dolore dolor sint",
-                        "role": "sit Excepteur nisi"
+                        "full_name": "do mollit velit",
+                        "role": "et"
                     },
                     {
-                        "full_name": "voluptate",
-                        "role": "aliquip in adipisicing ips"
-                    },
-                    {
-                        "full_name": "enim",
-                        "role": "amet ex Duis aliqua velit"
-                    },
-                    {
-                        "full_name": "ea",
-                        "role": "tempor eiusmod Ut esse in"
+                        "full_name": "velit",
+                        "role": "irure consequat in i"
                     }
                 ],
                 "book_series": {
-                    "title": "Duis ex id",
-                    "volume": "magna esse dolore culpa enim"
+                    "title": "fugiat velit sint culpa enim",
+                    "volume": "fugiat ad reprehenderit cillum"
                 },
                 "collaboration": [
-                    "cillum",
-                    "consequat et dolore ullamco non",
-                    "aliquip in consequat",
-                    "do ex Lorem qui sed",
-                    "quis"
+                    "voluptate do in dolore"
                 ],
                 "dois": [
-                    "10.3.5556847003/YVC8Aa|sy{",
-                    "10.433903.96137/hnNtz9"
+                    "10.07797/IWh.,@ssj>",
+                    "10.603260/MxEdDKR",
+                    "10.84282100.945630011/yr",
+                    "10.876.14470762/@"
                 ],
                 "imprint": {
                     "date": "dddd-dd-dd",
-                    "place": "ad nostrud dolore et",
-                    "publisher": "nulla irure ex proident"
+                    "place": "laborum ullamco consequat sint ut",
+                    "publisher": "tempor eu est dolor velit"
                 },
                 "misc": [
-                    "aliqua in fugiat",
-                    "eu tempor",
-                    "deserunt ullamco ipsum labore proident",
-                    "ipsum eiusmod incididunt dolor"
+                    "amet anim",
+                    "fugiat"
                 ],
-                "number": -51179695,
+                "number": 84289329,
                 "persistent_identifiers": [
-                    "nulla occaecat"
+                    "sint elit Duis"
                 ],
                 "publication_info": {
-                    "artid": "incididunt laborum",
-                    "cnum": "reprehenderit nulla Ut enim",
-                    "isbn": "ad anim esse est Excepteur",
-                    "journal_issue": "occaecat enim et aliqu",
-                    "journal_title": "ut la",
-                    "journal_volume": "occaecat Excepteur eiusmod velit",
-                    "page_end": "ut",
-                    "page_start": "ex reprehenderit aliquip ad nulla",
-                    "reportnumber": "ut Ut",
-                    "year": 1273
+                    "artid": "in officia sint",
+                    "cnum": "laborum nulla amet",
+                    "isbn": "commodo aute",
+                    "journal_issue": "culpa",
+                    "journal_title": "non irure cillum dolor",
+                    "journal_volume": "non labore ullamco veniam",
+                    "page_end": "amet deserunt",
+                    "page_start": "",
+                    "reportnumber": "in esse dolor in",
+                    "year": 1361
                 },
-                "texkey": "in",
+                "texkey": "nulla dolor eu",
                 "titles": [
                     {
-                        "source": "ex labore quis id fugiat",
-                        "subtitle": "magna",
-                        "title": "irure aliqua minim nulla in"
+                        "source": "do",
+                        "subtitle": "ea aliquip",
+                        "title": "id proident"
                     },
                     {
-                        "source": "exercitation aliqua aute irure labore",
-                        "subtitle": "sunt ea exercitation",
-                        "title": "cupidatat quis Lorem tempor enim"
+                        "source": "labore",
+                        "subtitle": "sit",
+                        "title": "minim ullamco adipisicing occaecat"
+                    },
+                    {
+                        "source": "ut",
+                        "subtitle": "sit dolore ad",
+                        "title": "ut aliquip"
+                    },
+                    {
+                        "source": "pariatur ut reprehenderit Ut",
+                        "subtitle": "velit",
+                        "title": "officia"
+                    },
+                    {
+                        "source": "fugiat non ullamco Excepteur sit",
+                        "subtitle": "aliqua",
+                        "title": "magna"
                     }
                 ],
                 "urls": [
                     {
-                        "description": "aliqua dolor",
-                        "value": "http://1;"
+                        "description": "ex officia magna anim",
+                        "value": "http://19p%"
                     },
                     {
-                        "description": "sunt occaecat magna officia labore",
-                        "value": "http://1("
+                        "description": "laboris in amet in dolor",
+                        "value": "http://1v*zXb"
                     },
                     {
-                        "description": "do aliquip incididunt aute anim",
-                        "value": "http://1"
+                        "description": "ut non ex aute qui",
+                        "value": "http://1z&i"
                     },
                     {
-                        "description": "nostrud Excepteur",
-                        "value": "http://1uC7i,i#H"
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": true,
-            "raw_refs": [
-                {
-                    "position": "nostrud re",
-                    "schema": "id ex nisi dolore",
-                    "source": "enim non Lorem est aliqua",
-                    "value": "Lorem eiusmod ut e"
-                }
-            ],
-            "record": {
-                "$ref": "http://1Nr"
-            },
-            "reference": {
-                "arxiv_eprints": [
-                    "2488.9297",
-                    "4231T7799",
-                    "vm8MK-VvqxS85m/295196",
-                    "0257p35239"
-                ],
-                "authors": [
-                    {
-                        "full_name": "fugiat in cupidatat sint laborum",
-                        "role": "pariatur"
+                        "description": "in",
+                        "value": "http://1'IzDi_"
                     },
                     {
-                        "full_name": "cupidatat voluptate aute Duis ipsum",
-                        "role": "consequat"
-                    },
-                    {
-                        "full_name": "reprehenderit",
-                        "role": "velit culpa labore Ut nos"
-                    }
-                ],
-                "book_series": {
-                    "title": "sunt Excepteur in ea",
-                    "volume": "minim d"
-                },
-                "collaboration": [
-                    "id incididunt"
-                ],
-                "dois": [
-                    "10.77.1215467249/\\EGP=",
-                    "10.340182891/B%-",
-                    "10.77298.70/?@EJq,["
-                ],
-                "imprint": {
-                    "date": "dddd-dd-dd",
-                    "place": "ipsum in eiusmod in tempor",
-                    "publisher": "nulla"
-                },
-                "misc": [
-                    "pariatur culpa eiusmod",
-                    "quis Excepteur",
-                    "elit tempor"
-                ],
-                "number": -78989176,
-                "persistent_identifiers": [
-                    "elit est aute in"
-                ],
-                "publication_info": {
-                    "artid": "Ut voluptate nulla qui",
-                    "cnum": "elit",
-                    "isbn": "aute incididunt proident est",
-                    "journal_issue": "exercitation inci",
-                    "journal_title": "Duis",
-                    "journal_volume": "in voluptate irure",
-                    "page_end": "voluptate aute",
-                    "page_start": "Lorem ipsum magna veniam cillum",
-                    "reportnumber": "magna aute",
-                    "year": 1120
-                },
-                "texkey": "incididunt aliqua",
-                "titles": [
-                    {
-                        "source": "occaeca",
-                        "subtitle": "nostrud in et aute ea",
-                        "title": "exercitation sint pariatur esse"
-                    },
-                    {
-                        "source": "sed voluptate enim consequat sunt",
-                        "subtitle": "eiusmod ad consectetur",
-                        "title": "Duis reprehenderit elit Ut"
-                    },
-                    {
-                        "source": "tempor dolor",
-                        "subtitle": "do consectetur consequat pariatur",
-                        "title": "Excepteu"
-                    },
-                    {
-                        "source": "reprehenderit ",
-                        "subtitle": "minim voluptate esse sint nisi",
-                        "title": "velit magna exercitation cupidatat"
-                    },
-                    {
-                        "source": "exercitation",
-                        "subtitle": "in cillum velit commodo",
-                        "title": "fugiat"
-                    }
-                ],
-                "urls": [
-                    {
-                        "description": "quis qui enim nostrud cillum",
-                        "value": "http://1AL=N2"
+                        "description": "sunt enim",
+                        "value": "http://10rDmb"
                     }
                 ]
             }
@@ -1155,117 +1030,140 @@
     "report_numbers": [
         {
             "hidden": false,
-            "source": "sit quis in Excepteur dolore",
-            "value": "minim"
+            "source": "laborum dolore culpa ut",
+            "value": "deserunt nulla id ex veniam"
+        },
+        {
+            "hidden": true,
+            "source": "sunt nulla",
+            "value": "id cillum in consequat nisi"
+        },
+        {
+            "hidden": false,
+            "source": "est magna in pariatur",
+            "value": "exercitation Excepteur in"
+        },
+        {
+            "hidden": false,
+            "source": "ipsum ea elit dolore",
+            "value": "anim cupidatat nostrud"
+        },
+        {
+            "hidden": true,
+            "source": "est consectetur ut sint",
+            "value": "in eiusmod eu do in"
         }
     ],
     "self": {
-        "$ref": "http://1e$kfXM"
+        "$ref": "http://1lW}!*c"
     },
     "special_collections": [
-        "CDF-NOTE"
+        "LARSOFT-NOTE",
+        "CDF-INTERNAL-NOTE",
+        "HERMES-INTERNAL-NOTE",
+        "ZEUS-PRELIMINARY-NOTE",
+        "CDS"
     ],
     "succeeding_entry": {
-        "isbn": "084332549X",
+        "isbn": "9785999343517",
         "record": {
-            "$ref": "http://1=j{u}TTR,="
+            "$ref": "http://1Yp.:cIA"
         },
-        "relationship_code": "incididunt ad dolor"
+        "relationship_code": "eiusmod"
     },
     "texkeys": [
-        "aute dolor minim quis",
-        "Excepteur ut deserunt"
+        "sit enim aute",
+        "exercitation incididunt fugiat",
+        "Excepteur"
     ],
     "thesis_info": {
         "date": "dddd-dd-dd",
         "defense_date": "dddd-dd-dd",
-        "degree_type": "other",
+        "degree_type": "habilitation",
         "institutions": [
             {
                 "curated_relation": false,
-                "name": "Ut adipisicing reprehenderit in",
+                "name": "elit eiusmod adipisicing",
                 "record": {
-                    "$ref": "http://1Xh=e"
+                    "$ref": "http://1w"
                 }
             },
             {
                 "curated_relation": false,
-                "name": "a",
+                "name": "ad Ut amet in",
                 "record": {
-                    "$ref": "http://1\"4R9R1G}B5"
-                }
-            },
-            {
-                "curated_relation": true,
-                "name": "aliquip ut officia",
-                "record": {
-                    "$ref": "http://1D@*1GN"
-                }
-            },
-            {
-                "curated_relation": false,
-                "name": "esse occaecat dolore eiusmod",
-                "record": {
-                    "$ref": "http://1yru ){`{qF"
-                }
-            },
-            {
-                "curated_relation": false,
-                "name": "eiusmod laborum deserunt",
-                "record": {
-                    "$ref": "http://1C"
+                    "$ref": "http://1mK8G?"
                 }
             }
         ]
     },
     "title_translations": [
         {
-            "language": "4S",
-            "source": "Lorem in i",
-            "subtitle": "Excepte",
-            "title": "qui occaecat ullamco"
+            "language": "2L",
+            "source": "reprehenderit",
+            "subtitle": "sed consequat dolor nisi",
+            "title": "sunt ex magna"
         },
         {
-            "language": "re",
-            "source": "cupidatat veniam exercitation",
-            "subtitle": "culpa consequat venia",
-            "title": "esse officia laborum adipisicing dolore"
+            "language": "NI",
+            "source": "dolore ullamco",
+            "subtitle": "ad cupidatat commodo",
+            "title": "ex ut adipisicing cupidatat "
         },
         {
-            "language": "CV",
-            "source": "ad dolor",
-            "subtitle": "sint nulla officia commodo",
-            "title": "minim Duis Excepteur"
+            "language": "w3",
+            "source": "minim Ut irure aute commodo",
+            "subtitle": "do in velit",
+            "title": "culpa eu in aute cillum"
         },
         {
-            "language": "H4",
-            "source": "sunt aliquip reprehenderit enim",
-            "subtitle": "esse dolore cillum ex exercitation",
-            "title": "aliqua"
+            "language": "KF",
+            "source": "adipisicing",
+            "subtitle": "culpa magna Ut sit",
+            "title": "incididunt minim dolor id aute"
         },
         {
-            "language": "sv",
-            "source": "adipisicing con",
-            "subtitle": "est labore do in",
-            "title": "enim pariatur culpa ut sit"
+            "language": "35",
+            "source": "nulla",
+            "subtitle": "",
+            "title": "irure cupidatat"
         }
     ],
     "titles": [
         {
-            "source": "irure reprehenderit qui ut veniam",
-            "subtitle": "proident aliqua qui",
-            "title": "labore sed eiusmod"
+            "source": "nisi ipsum",
+            "subtitle": "aute officia amet",
+            "title": "adipisicing"
+        },
+        {
+            "source": "ex",
+            "subtitle": "laborum in",
+            "title": "eu sed do ad"
+        },
+        {
+            "source": "ad Excepteur officia ex quis",
+            "subtitle": "et cillum tempor",
+            "title": "in minim aute pariatur"
+        },
+        {
+            "source": "in eiusmod",
+            "subtitle": "ullamco ad",
+            "title": "aliqua incididunt"
         }
     ],
     "urls": [
         {
-            "description": "cillum ut ex",
-            "value": "http://1vmT4T!"
+            "description": "ea deserunt occaecat laboris",
+            "value": "http://1squ"
         },
         {
-            "description": "eu",
-            "value": "http://1-\\r\\}"
+            "description": "qui Ut pariatur elit",
+            "value": "http://1k;+6@XVM]m"
+        },
+        {
+            "description": "amet magna elit incididunt ex",
+            "value": "http://1;fz"
         }
     ],
-    "withdrawn": false
+    "withdrawn": true
 }

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -1,159 +1,232 @@
 {
     "ICN": [
-        "id fugiat in nostrud ipsum"
+        "sint",
+        "Ut Duis sint nisi nostrud",
+        "est labore magna officia proident"
     ],
     "_collections": [
-        "elit cupidatat ex fugiat qui",
-        "minim deserunt veniam quis Lorem",
-        "labore dolor",
-        "non laboris velit sint quis"
+        "non id qui deserunt",
+        "eiusmod in tempor consequat",
+        "pariatur deserunt dolor qui"
     ],
     "_private_notes": [
         {
-            "source": "commodo proident",
-            "value": "labore tempor commodo"
+            "source": "commodo voluptate mollit minim",
+            "value": "sit"
+        },
+        {
+            "source": "nostrud",
+            "value": "laboris"
+        },
+        {
+            "source": "Excepteur nostrud sint eu",
+            "value": "sunt"
         }
     ],
     "address": [
         {
-            "city": "labore consectetur magna in",
-            "country_code": "MZ",
-            "latitude": 69485965,
-            "longitude": 98450206,
-            "original address": "officia",
-            "postal_code": "adipisicing sit anim",
-            "state": "Duis aliquip"
+            "city": "voluptate Lorem",
+            "country_code": "GP",
+            "latitude": -62452865,
+            "longitude": -40301415,
+            "original address": "in",
+            "postal_code": "nulla dolore aliqua est magna",
+            "state": "culpa minim veniam "
         },
         {
-            "city": "sint eu ad Duis mollit",
-            "country_code": "RO",
-            "latitude": 22192790,
-            "longitude": 51126227,
-            "original address": "minim consequat sit quis",
-            "postal_code": "sed reprehenderit",
-            "state": "Excepteur"
+            "city": "Lorem cillum sunt labore",
+            "country_code": "GM",
+            "latitude": -28484454,
+            "longitude": -41529102,
+            "original address": "anim pariatur occ",
+            "postal_code": "in laboris in ad nulla",
+            "state": "lab"
         },
         {
-            "city": "L",
-            "country_code": "ST",
-            "latitude": 873598,
-            "longitude": 41250509,
-            "original address": "sed",
-            "postal_code": "magna culpa pariatur ullamco irure",
-            "state": "exercitation adipisicing deserunt"
+            "city": "veniam",
+            "country_code": "MV",
+            "latitude": -46159778,
+            "longitude": 14541972,
+            "original address": "ullam",
+            "postal_code": "laborum deserunt",
+            "state": "magna Ut fugiat ullamco commodo"
         },
         {
-            "city": "Excepteur",
-            "country_code": "QA",
-            "latitude": -34590075,
-            "longitude": 65602467,
-            "original address": "est proident eu Lorem",
-            "postal_code": "enim eu velit nostr",
-            "state": "dolor id ea nostrud magna"
-        },
-        {
-            "city": "ut pariatur velit reprehenderit sit",
-            "country_code": "CN",
-            "latitude": -31121890,
-            "longitude": 46816425,
-            "original address": "tempor velit id reprehenderit",
-            "postal_code": "labore ut proident",
-            "state": "ipsum Duis eiusmod Excepteur"
+            "city": "aliquip quis",
+            "country_code": "GY",
+            "latitude": -11773280,
+            "longitude": -1734131,
+            "original address": "dolor occaecat aute",
+            "postal_code": "ex officia",
+            "state": "proident Excepteur ex in "
         }
     ],
-    "control_number": 97213093,
-    "core": true,
-    "deleted": false,
+    "control_number": 16750881,
+    "core": false,
+    "deleted": true,
     "department": [
-        "irure c",
-        "mollit",
-        "sit adi"
+        "Except"
     ],
-    "department_acronym": "do proident ullamco est",
+    "department_acronym": "nulla sed",
+    "external_system_identifiers": [
+        {
+            "type": "HAL",
+            "value": "37500942"
+        },
+        {
+            "type": "HAL",
+            "value": "44968"
+        },
+        {
+            "type": "HAL",
+            "value": "86851978267"
+        },
+        {
+            "type": "HAL",
+            "value": "2565683282"
+        },
+        {
+            "type": "HAL",
+            "value": "35415"
+        }
+    ],
     "extra_words": [
-        "ci"
+        "",
+        "aliquip nulla",
+        "cons"
     ],
     "field_activity": [
-        "Other",
-        "Research Center"
+        "Research Center",
+        "Company",
+        "Research Center",
+        "Company",
+        "Company"
     ],
     "historical_data": [
-        "Excepteur"
-    ],
-    "ids": [
-        {
-            "type": "HAL",
-            "value": "648594"
-        },
-        {
-            "type": "HAL",
-            "value": "7732520"
-        }
+        "culpa eiusmod Lorem consectetur",
+        "proident ut veniam minim sit",
+        "ullamco nulla Ut esse"
     ],
     "inspire_categories": [
         {
-            "source": "undefined",
+            "source": "curator",
+            "term": "Data Analysis and Statistics"
+        },
+        {
+            "source": "curator",
+            "term": "Accelerators"
+        },
+        {
+            "source": "arxiv",
             "term": "Data Analysis and Statistics"
         },
         {
             "source": "arxiv",
-            "term": "Theory-HEP"
+            "term": "Math and Math Physics"
         }
     ],
     "institution": [
-        "nisi aliquip amet tempor consectetur"
+        "Ut",
+        "fugiat",
+        "eiusmod ut commodo et anim",
+        "veniam dolor",
+        "dolore officia eu"
     ],
-    "institution_acronym": "veniam pariatur voluptate officia",
-    "legacy_creation_date": "3530-02-17T12:31:38.799Z",
+    "institution_acronym": "dolor non",
+    "legacy_creation_date": "3000-08-23T19:38:23.576Z",
     "location": {
-        "latitude": 18817304,
-        "longitude": 76645825
+        "latitude": -6024048,
+        "longitude": -23028179
     },
     "name_variants": [
         {
-            "source": "aliqua quis",
-            "value": "do Duis"
+            "source": "sed ",
+            "value": "con"
+        },
+        {
+            "source": "quis",
+            "value": "proident sunt nulla dolore"
+        },
+        {
+            "source": "esse",
+            "value": "Excepteur aliqua"
+        },
+        {
+            "source": "aliqua et qui",
+            "value": "nulla enim Duis"
+        },
+        {
+            "source": "eiusmod esse in ut est",
+            "value": "commodo id"
         }
     ],
     "new_record": {
-        "$ref": "http://1nEh"
+        "$ref": "http://1X8X"
     },
     "public_notes": [
         {
-            "source": "adipisicing commodo",
-            "value": "commodo sint elit"
-        },
-        {
-            "source": "magna eu ullamco",
-            "value": "veniam ex dolore culpa occaecat"
+            "source": "mini",
+            "value": "consequat qui"
         }
     ],
     "related_institutes": [
         {
-            "curated_relation": true,
-            "name": "non consectetur aliquip adipisicing in",
+            "curated_relation": false,
+            "name": "ex labore",
             "record": {
-                "$ref": "http://1wS"
+                "$ref": "http://1Nk "
             },
-            "relation_type": "successor"
+            "relation_type": "parent"
         },
         {
             "curated_relation": true,
-            "name": "sunt deserunt",
+            "name": "ea fugiat eiusmod",
             "record": {
-                "$ref": "http://1'l]O"
+                "$ref": "http://16y}i~Z"
             },
-            "relation_type": "other"
+            "relation_type": "predecessor"
+        },
+        {
+            "curated_relation": false,
+            "name": "sed incididunt nulla commodo sint",
+            "record": {
+                "$ref": "http://1\\Kh:MT"
+            },
+            "relation_type": "predecessor"
+        },
+        {
+            "curated_relation": true,
+            "name": "ex magna velit ipsum",
+            "record": {
+                "$ref": "http://1fh\"P5H|"
+            },
+            "relation_type": "successor"
         }
     ],
     "self": {
-        "$ref": "http://1l*ht#Ug\\j"
+        "$ref": "http://1KNY]9@=w"
     },
-    "time_zone": "there",
+    "time_zone": "be",
     "urls": [
         {
-            "description": "anim enim laboris et",
-            "value": "http://15R_O$cB"
+            "description": "aliqua",
+            "value": "http://1Z{t@0"
+        },
+        {
+            "description": "Lorem id consequat officia do",
+            "value": "http://1%~S"
+        },
+        {
+            "description": "cillum consequat mollit tempor",
+            "value": "http://1d>{|yE6["
+        },
+        {
+            "description": "Lorem",
+            "value": "http://1K=KT+3;c{%"
+        },
+        {
+            "description": "Excepteur qui consequat veniam c",
+            "value": "http://1KFf"
         }
     ]
 }

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -1,187 +1,193 @@
 {
     "_collections": [
-        "incididunt elit",
-        "reprehenderit"
+        "aliqua",
+        "dolore",
+        "sint voluptate in cupidatat in",
+        "Excepteur enim nisi sit"
     ],
     "_private_notes": [
         {
-            "source": "dolore",
-            "value": "enim"
+            "source": "reprehenderit",
+            "value": "Excepteur mollit elit ut cupidatat"
         },
         {
-            "source": "non aliqua",
-            "value": "eu magna commodo"
+            "source": "laborum tempor dolor aliqua ea",
+            "value": "culpa cupidatat ullamco tempor"
         },
         {
-            "source": "qui non elit reprehenderit consequat",
-            "value": "voluptate ad in"
+            "source": "dolor consequat dolore quis Ut",
+            "value": "fugiat"
+        },
+        {
+            "source": "dolore occaecat proident",
+            "value": "oc"
         }
     ],
     "address": [
         {
-            "city": "pariatur consectetur quis",
-            "country_code": "NZ",
-            "latitude": -82486896,
-            "longitude": 46696048,
-            "original address": "elit aliquip non sit laboris",
-            "postal_code": "consectetur sunt dolor dolor si",
-            "state": "pariatur occaecat sint sit"
+            "city": "sit sed in",
+            "country_code": "KM",
+            "latitude": 24522849,
+            "longitude": -63520669,
+            "original address": "velit ullamco id qui consequat",
+            "postal_code": "ea pariatur incididunt et",
+            "state": "aliquip occaecat"
         },
         {
-            "city": "officia labore",
-            "country_code": "AM",
-            "latitude": -88249972,
-            "longitude": -70128018,
-            "original address": "occaecat Duis",
-            "postal_code": "dolor id adipisicing qui sint",
-            "state": "ullamco id Duis non commodo"
+            "city": "occaecat dolore",
+            "country_code": "IQ",
+            "latitude": 42114813,
+            "longitude": -4208173,
+            "original address": "amet",
+            "postal_code": "laboris proident exercitation deserunt",
+            "state": "exercitation dolor"
         },
         {
-            "city": "labore",
-            "country_code": "LY",
-            "latitude": 40888503,
-            "longitude": -95637117,
-            "original address": "pariatur",
-            "postal_code": "quis esse",
-            "state": "adipisicing enim"
+            "city": "consequa",
+            "country_code": "MF",
+            "latitude": 859507,
+            "longitude": -32744513,
+            "original address": "dolore Excepteur officia",
+            "postal_code": "aliqua reprehenderit",
+            "state": "ex anim occaecat sit"
         },
         {
-            "city": "ullamco pariatur ipsum laboris fugiat",
-            "country_code": "PF",
-            "latitude": -73598036,
-            "longitude": 58443987,
-            "original address": "non exerci",
-            "postal_code": "ullamco nisi ex sed anim",
-            "state": "e"
+            "city": "culpa cillum nostrud mollit",
+            "country_code": "GM",
+            "latitude": -30981525,
+            "longitude": 71927642,
+            "original address": "aliqua laboris ullamco Duis",
+            "postal_code": "aute do",
+            "state": "sunt"
+        },
+        {
+            "city": "consectetur sint laboris",
+            "country_code": "ET",
+            "latitude": 75919143,
+            "longitude": 85814236,
+            "original address": "ut anim dolor occaecat velit",
+            "postal_code": "dolore",
+            "state": "laboris dolore"
         }
     ],
     "closed_date": "dddd-dd-dd",
     "contact_details": [
         {
-            "email": "k4QFN57iI75qKIo@yqvxdkacNDfBPvEeeTfJs.hq",
-            "name": "nisi laboris"
+            "email": "L5fUf@QsofdBOEflmVQ.hl",
+            "name": "in"
+        },
+        {
+            "email": "eMiPeK8X1@xGnc.qb",
+            "name": "veniam cupidatat"
+        },
+        {
+            "email": "EPWaPSJPJ-v1@Nwt.xg",
+            "name": "in sunt mollit dolor magna"
         }
     ],
-    "control_number": 36803525,
+    "control_number": 80091570,
     "deadline_date": "dddd-dd-dd",
     "deleted": false,
-    "description": "in anim la",
+    "description": "pariatur id",
     "experiments": [
         {
-            "curated_relation": true,
-            "name": "aliquip id commodo nulla exercitation",
+            "curated_relation": false,
+            "name": "et eu est in tempor",
             "record": {
-                "$ref": "http://11.5j[|O[I"
+                "$ref": "http://1Hd1/"
             }
+        }
+    ],
+    "external_system_identifiers": [
+        {
+            "type": "SPIRES",
+            "value": "JOBS-18167611033"
         },
         {
-            "curated_relation": false,
-            "name": "dolor veniam non velit qui",
-            "record": {
-                "$ref": "http://1C"
-            }
-        },
-        {
-            "curated_relation": false,
-            "name": "amet aute dolor proident sed",
-            "record": {
-                "$ref": "http://1\"CZ_0uf$"
-            }
-        },
-        {
-            "curated_relation": false,
-            "name": "in nulla",
-            "record": {
-                "$ref": "http://13TRJ-XKue;"
-            }
+            "type": "SPIRES",
+            "value": "JOBS-61297838921"
         }
     ],
     "inspire_categories": [
         {
             "source": "arxiv",
-            "term": "Lattice"
-        },
-        {
-            "source": "curator",
-            "term": "Computing"
-        },
-        {
-            "source": "user",
-            "term": "Theory-HEP"
-        },
-        {
-            "source": "arxiv",
-            "term": "Computing"
-        },
-        {
-            "source": "user",
-            "term": "Experiment-Nucl"
+            "term": "Math and Math Physics"
         }
     ],
     "institutions": [
         {
-            "curated_relation": false,
-            "name": "nisi aliquip aute do nulla",
+            "curated_relation": true,
+            "name": "ex do quis Excepteur",
             "record": {
-                "$ref": "http://1I[-81j7cb"
+                "$ref": "http://1;i*o"
+            }
+        },
+        {
+            "curated_relation": false,
+            "name": "nostrud ea aliquip dolore",
+            "record": {
+                "$ref": "http://1)1c}N(Md"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "ex ea",
+            "record": {
+                "$ref": "http://1"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "eiusmod minim voluptate",
+            "record": {
+                "$ref": "http://19yiz "
             }
         }
     ],
-    "legacy_creation_date": "2637-10-14T22:55:24.160Z",
+    "legacy_creation_date": "2876-03-23T22:43:28.182Z",
     "new_record": {
-        "$ref": "http://16:Xmw"
+        "$ref": "http://1+G$xYjrCI"
     },
-    "position": "aliqua deserunt culpa ad ullamco",
+    "position": "fugiat mollit officia in",
     "public_notes": [
         {
-            "source": "",
-            "value": "sunt"
+            "source": "ex dolore irure enim Lorem",
+            "value": "in veniam adipisicing dolore"
         },
         {
-            "source": "Lorem ut dolore",
-            "value": "do"
-        },
-        {
-            "source": "",
-            "value": "esse"
-        },
-        {
-            "source": "consequat cupidatat sunt",
-            "value": "fugiat"
+            "source": "mollit",
+            "value": "proident in pariatur"
         }
     ],
     "ranks": [
+        "SENIOR",
+        "POSTDOC",
         "JUNIOR",
-        "VISITOR",
-        "POSTDOC"
+        "OTHER",
+        "VISITOR"
     ],
     "reference_email": [
-        "znh52eARQyF@UQSAWeKKsTwTNd.fr",
-        "TWmKze9yKti@SLjOCDnxaoOppJCiNlYYeMWc.xb",
-        "OzSqB8FtUV@oWqQdpPStrwVYQWcWMQyGNtQV.lzt",
-        "FZY7TnI@NCYuGBqWvcvXMPAOjMIKalWrtklfV.rjc"
+        "MnR3TXGfkkQFU@kacVYCvFJAzHeOTcXBoukfRXEKKrIrfg.rt",
+        "AiNW4yOHUaV@xIZDKvEjsWofGitHHxmuhZeizZR.dbx"
     ],
     "regions": [
-        "Middle East",
-        "Middle East",
-        "Asia",
-        "Asia"
+        "Australasia",
+        "Africa",
+        "South America",
+        "Europe",
+        "North America"
     ],
     "self": {
-        "$ref": "http://11k\\WA"
+        "$ref": "http://1A"
     },
     "urls": [
         {
-            "description": "ut nostrud",
-            "value": "http://1"
+            "description": "dolor ut Duis veniam velit",
+            "value": "http://1eV"
         },
         {
-            "description": "Ut eiusmod",
-            "value": "http://1gl"
-        },
-        {
-            "description": "ullamco magna Duis in",
-            "value": "http://1`d#"
+            "description": "ad mollit aute",
+            "value": "http://1F*&~U}"
         }
     ]
 }

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -1,153 +1,183 @@
 {
     "_collections": [
-        "nostrud labore anim Excepteur et",
-        "elit incididunt et",
-        "nulla",
-        "cillum pariatur cupidatat",
-        "nostrud est"
+        "Excepteur aliquip id",
+        "ea in veniam do ut",
+        "Duis non occaecat comm",
+        "amet Duis sed deserunt nostrud"
     ],
     "_private_notes": [
         {
-            "source": "reprehenderit",
-            "value": "Duis dolor qui"
+            "source": "in",
+            "value": "nulla magna reprehenderit"
         },
         {
-            "source": "elit commodo",
-            "value": "ad irure amet ea"
+            "source": "in D",
+            "value": "non exercitation"
         },
         {
-            "source": "occaecat est",
-            "value": "eu"
-        },
-        {
-            "source": "dolor consectetur dolor do aute",
-            "value": "exercitation Excepteu"
+            "source": "dolore",
+            "value": "culpa eiusmod mollit proident"
         }
     ],
     "coden": [
-        "WMA4",
-        "NZ0G1",
-        "HLNW"
+        "AEI-C",
+        "R2XR1",
+        "X4RV",
+        "BJBTL"
     ],
-    "control_number": -79193899,
+    "control_number": -43117562,
     "deleted": true,
-    "history": "irure incididunt exercitation consectetur tempor",
+    "history": "est",
     "issn": [
         {
-            "comment": "reprehenderit aliqua elit laborum culpa",
+            "comment": "occaecat elit commodo nostrud",
             "medium": "online",
-            "value": "3010-409X"
+            "value": "5013-0599"
+        },
+        {
+            "comment": "aliquip dolor id",
+            "medium": "print",
+            "value": "7815-2139"
         }
     ],
-    "journal_handling": "o",
+    "journal_handling": "officia non sit ullamco",
     "journal_titles": [
         {
-            "source": "ad ipsum eu in",
-            "subtitle": "pariatur Lorem proident esse dolore",
-            "title": "exercitation labore nulla Duis"
+            "source": "nisi",
+            "subtitle": "aliquip fugiat sunt officia",
+            "title": "velit elit aliqua voluptate al"
         },
         {
-            "source": "in sunt aliquip officia",
-            "subtitle": "exercitation sunt nostrud non",
-            "title": "sunt consequat dolor dolore Lorem"
+            "source": "dolor do ut Lorem velit",
+            "subtitle": "laboris",
+            "title": "qui proident do"
         },
         {
-            "source": "in",
-            "subtitle": "do aute deserunt irure in",
-            "title": "elit"
+            "source": "consectetur ut",
+            "subtitle": "ut Ut",
+            "title": "consequat ut"
+        },
+        {
+            "source": "laborum consequat",
+            "subtitle": "sit amet dolor cillum",
+            "title": "velit in"
+        },
+        {
+            "source": "dolore ipsum proident se",
+            "subtitle": "occaecat laboris proident sed",
+            "title": "enim culpa nisi sunt eu"
         }
     ],
-    "legacy_creation_date": "2000-07-04T18:18:13.524Z",
-    "license": "it",
+    "legacy_creation_date": "3633-03-19T16:24:55.150Z",
+    "license": "probably",
     "license_urls": [
         {
-            "description": "dolor tempor labore",
-            "value": "http://1$b"
+            "description": "in velit proident ut",
+            "value": "http://1:)w6^Sux;_"
         },
         {
-            "description": "esse eu veniam elit",
-            "value": "http://1RE"
+            "description": "Ut quis velit consequat aliquip",
+            "value": "http://1f-"
         }
     ],
     "new_record": {
-        "$ref": "http://1"
+        "$ref": "http://1hnoM\"5eSKL"
     },
     "peer_reviewed": true,
     "public_notes": [
         {
-            "source": "consequat ipsum commodo ex in",
-            "value": "eni"
+            "source": "nostrud in in",
+            "value": "veniam dolor reprehen"
+        },
+        {
+            "source": "esse voluptate ullamco incididunt",
+            "value": "tempor proident sed"
+        },
+        {
+            "source": "deserunt elit sit",
+            "value": "in laboris amet"
+        },
+        {
+            "source": "laboris mollit dolore",
+            "value": "tempor ut dolore laboris pariatur"
         }
     ],
     "publisher": [
-        "pariatur do consequat",
-        "do officia"
+        "velit consequat",
+        "voluptate adipisicing in est",
+        "exercitation deserunt",
+        "qui tempor ad nulla commodo"
     ],
     "relation": {
-        "curated_relation": false,
-        "issn": "9418-1045",
+        "curated_relation": true,
+        "issn": "2374-0319",
         "record": {
-            "$ref": "http://1M\\:"
+            "$ref": "http://1v96F"
         },
         "relation": "superseeding record"
     },
     "self": {
-        "$ref": "http://1"
+        "$ref": "http://1Hfl"
     },
     "short_titles": [
         {
-            "source": "eiusmod ea",
-            "subtitle": "nisi",
-            "title": "dolore tempor"
+            "source": "culpa ex",
+            "subtitle": "minim in officia",
+            "title": "nulla aliquip laborum labore reprehenderit"
         },
         {
-            "source": "in ex qui Excepteur",
-            "subtitle": "sed eu officia cupidatat sint",
-            "title": "pariatur nisi laboris"
+            "source": "deserunt aute cillum dolor occaecat",
+            "subtitle": "nulla reprehenderit",
+            "title": "laboris id non nisi enim"
         },
         {
-            "source": "quis est proident",
-            "subtitle": "elit amet aliquip in aliqua",
-            "title": "reprehenderit magna consequat"
+            "source": "eiusmod Ut laborum incididunt",
+            "subtitle": "amet reprehenderit",
+            "title": "labore quis"
         },
         {
-            "source": "dolor off",
-            "subtitle": "eiusmod",
-            "title": "quis"
+            "source": "incididunt magna amet occaecat ",
+            "subtitle": "",
+            "title": "elit adipisicing reprehender"
         }
     ],
     "title_variants": [
         {
-            "source": "sint tempor dolor nisi",
-            "subtitle": "officia deserunt quis",
-            "title": "nostrud amet"
+            "source": "laborum",
+            "subtitle": "irure nostrud proident",
+            "title": "anim ea"
         },
         {
-            "source": "aliquip commodo aliqua exe",
-            "subtitle": "voluptate culpa in ea amet",
-            "title": "Duis"
+            "source": "ex in dolor Excepteur quis",
+            "subtitle": "mollit occaecat deserunt nisi",
+            "title": "id dolor ea"
+        },
+        {
+            "source": "Excepteur occaecat in",
+            "subtitle": "officia culpa minim",
+            "title": "nisi elit in reprehenderit"
         }
     ],
     "urls": [
         {
-            "description": "consectetur",
-            "value": "http://1\\bef;\"ka`"
+            "description": "minim consectetur",
+            "value": "http://1X$9 .CSj"
         },
         {
-            "description": "nos",
-            "value": "http://1k"
+            "description": "dolor anim",
+            "value": "http://1',h*:=z"
         },
         {
-            "description": "fugiat",
-            "value": "http://1K]1t@>T'0N"
+            "description": "sit voluptate laboris",
+            "value": "http://1 MjU"
         },
         {
-            "description": "quis voluptate",
-            "value": "http://1*Gt'x-"
+            "description": "irure cupidatat consectetur",
+            "value": "http://1#Q:`z"
         },
         {
-            "description": "adipisicing",
-            "value": "http://1W<n"
+            "description": "nulla fugiat officia",
+            "value": "http://1b^+!G>7xj"
         }
     ]
 }


### PR DESCRIPTION
* Adds `external_system_identifiers` for all schemas but authors (which
uses `ids` instead, containing both internal and external identifiers).
* INCOMPATIBLE Renames in institutions `ids` to
`external_system_identifiers` for consistency.

Signed-off-by: Micha Moskovic <michamos@gmail.com>