### PR TITLE
tests: remove useless pydocstyle

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -23,7 +23,6 @@
 check-manifest>=0.25
 coverage>=4.0
 isort>=4.2.2
-pydocstyle>=1.0.0
 pytest-cache>=1.0
 pytest-cov>=1.8.0
 pytest-pep8>=1.0.6

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -53,7 +53,6 @@ check_prettified() {
 }
 
 
-pydocstyle --explain --source inspire_schemas tests && \
 isort -rc -c --skip docs/conf.py -df **/*.py && \
 pytest \
     --pep8 \


### PR DESCRIPTION
Also forcing a new release with the correct version. This commit might
be reverted after if so decided in the documentation meeting.

Signed-off-by: David Caro <david@dcaro.es>