### PR TITLE
elements: expand regexp for BAIs

### DIFF
--- a/inspire_schemas/records/elements/id.json
+++ b/inspire_schemas/records/elements/id.json
@@ -31,7 +31,7 @@
                     "type": "string"
                 },
                 "value": {
-                    "pattern": "^(\\w+\\.)+\\d+$",
+                    "pattern": "^((\\w|\\-|\\')+\\.)+\\d+$",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
```python
In [1]: schema = {'pattern': '^((\w|\-|\')+\.)+\d+$', 'type': 'string'}

In [2]: validate('L.Dell\'Asta.1', schema)

In [3]: validate('T.J.Berners-Lee.1', schema)

In [4]: with open('035__a_when_9_is_BAI.txt', 'r') as f:
   ...:     for line in f:
   ...:         try:
   ...:             validate(line.strip(), schema)
   ...:         except:
   ...:             print(line.strip())
```
prints
```
0000-0002-2836-6085
INSPIRE-00627028
INSPIRE-00584874
.J.M.Snellings.1
Qing.Ping.Ji.
Qi.Fang.Lü.1
10115251
.F.Schonfeld.1
```
where `035__a_when_9_is_BAI.txt` is a file containing all the BAIs I could find in HEPNames. These outliers could be interesting for @inspirehep/inspire-content. We don't want to allow characters like "ü" in BAIs, right?