### PR TITLE
hep: remove CDS from special_collections

### DIFF
--- a/inspire_schemas/records/hep.json
+++ b/inspire_schemas/records/hep.json
@@ -865,7 +865,6 @@
                 "enum": [
                     "CDF-INTERNAL-NOTE",
                     "CDF-NOTE",
-                    "CDS",
                     "D0-INTERNAL-NOTE",
                     "D0-PRELIMINARY-NOTE",
                     "H1-INTERNAL-NOTE",


### PR DESCRIPTION
* INCOMPATIBLE Removes CDS from the allowed values of
`special_collections`, as `special_collections = ['CDS']` has been
superseded by `_export_to.CDS = true` in aee49d8.

Signed-off-by: Micha Moskovic <michamos@gmail.com>