### PR TITLE
builders: fix publication_info citeable logic

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -144,7 +144,6 @@ class LiteratureBuilder(object):
                 'value': doi,
                 'source': self._get_source(source),
             })
-            self.set_citeable(True)
 
     @filter_empty_parameters
     def add_author(self, author):
@@ -270,6 +269,36 @@ class LiteratureBuilder(object):
         the document has been published
         :type journal_volume: string
         """
+        def _is_citeable(publication_info):
+            """Check some fields in order to define if the article is citeable.
+
+            :param publication_info: publication_info field
+            already populated
+            :type publication_info: list
+            """
+            def _item_has_pub_info(item):
+                return all(
+                    key in item for key in (
+                        'year', 'journal_title', 'journal_volume'
+                    )
+                )
+
+            def _item_has_page_or_artid(item):
+                return any(
+                    key in item for key in (
+                        'page_start', 'artid'
+                    )
+                )
+
+            has_pub_info = any(
+                _item_has_pub_info(item) for item in publication_info
+            )
+            has_page_or_artid = any(
+                _item_has_page_or_artid(item) for item in publication_info
+            )
+
+            return has_pub_info and has_page_or_artid
+
         self.record.setdefault('publication_info', [])
 
         publication_item = {}
@@ -289,20 +318,7 @@ class LiteratureBuilder(object):
 
         self.record['publication_info'].append(publication_item)
 
-        # Consideration about citeable attribute
-        has_pub_info = all(
-            key in self.record['publication_info'] for key in (
-                'year', 'journal_issue', 'journal_volume'
-            )
-        )
-
-        has_page_or_artid = any(
-            key in self.record['publication_info'] for key in (
-                'page_start', 'page_end', 'artid'
-            )
-        )
-
-        if has_pub_info and has_page_or_artid:
+        if _is_citeable(self.record['publication_info']):
             self.set_citeable(True)
 
     @filter_empty_parameters


### PR DESCRIPTION
* Fixes the logic about citeable articles. Before it was considering
the publication_info field as an object rather than an array.

Signed-off-by: Riccardo Candido <riccardo.candido@gmail.com>