### PR TITLE
global: add deleted_records everywhere

### DIFF
--- a/inspire_schemas/records/authors.json
+++ b/inspire_schemas/records/authors.json
@@ -82,6 +82,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "email_addresses": {
             "description": "Contains current email addresses",
             "items": {

--- a/inspire_schemas/records/conferences.json
+++ b/inspire_schemas/records/conferences.json
@@ -61,6 +61,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "external_system_identifiers": {
             "items": {
                 "anyOf": [

--- a/inspire_schemas/records/experiments.json
+++ b/inspire_schemas/records/experiments.json
@@ -100,6 +100,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "description": {
             "items": {
                 "type": "string"

--- a/inspire_schemas/records/institutions.json
+++ b/inspire_schemas/records/institutions.json
@@ -45,6 +45,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "department": {
             "description": "Subordinate unit in native language",
             "items": {

--- a/inspire_schemas/records/jobs.json
+++ b/inspire_schemas/records/jobs.json
@@ -49,6 +49,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "description": {
             "title": "Job description",
             "type": "string"

--- a/inspire_schemas/records/journals.json
+++ b/inspire_schemas/records/journals.json
@@ -35,6 +35,14 @@
         "deleted": {
             "type": "boolean"
         },
+        "deleted_records": {
+            "description": "List of deleted records referring to this record",
+            "items": {
+                "$ref": "elements/json_reference.json"
+            },
+            "title": "Deleted Records",
+            "type": "array"
+        },
         "history": {
             "title": "History",
             "type": "string"

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -79,6 +79,17 @@
     "control_number": 90477573,
     "death_date": "dddd-dd-dd",
     "deleted": false,
+    "deleted_records": [
+        {
+            "$ref": "http://1Gn\"!"
+        },
+        {
+            "$ref": "http://13:i"
+        },
+        {
+            "$ref": "http://1Y8"
+        }
+    ],
     "email_addresses": [
         "f9OjAA1oirTIG@EqHWGPESGmpyaxmTIvYaFrwShMOuaO.soay",
         "oDUhoewqearoZI@ZHEkoVqiLfBhjRCzQRTrvEaTrdKUgDpMh.bprr"

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -103,6 +103,20 @@
     ],
     "control_number": -79718794,
     "deleted": false,
+    "deleted_records": [
+        {
+            "$ref": "http://1<"
+        },
+        {
+            "$ref": "http://18(@7\"["
+        },
+        {
+            "$ref": "http://1r79~{_"
+        },
+        {
+            "$ref": "http://1m^e!K:"
+        }
+    ],
     "external_system_identifiers": [
         {
             "schema": "SPIRES",

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -67,6 +67,23 @@
     "date_proposed": "dddd-dd-dd",
     "date_started": "dddd-dd-dd",
     "deleted": true,
+    "deleted_records": [
+        {
+            "$ref": "http://1{O4v\\AkLiO"
+        },
+        {
+            "$ref": "http://1kRT{Y[0:e5"
+        },
+        {
+            "$ref": "http://1)_nh2kE%"
+        },
+        {
+            "$ref": "http://1{"
+        },
+        {
+            "$ref": "http://1)f;]k#v4l!"
+        }
+    ],
     "description": [
         "id aute ut Excepteur incididunt",
         "fugiat Excepteur",

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -66,6 +66,11 @@
     "control_number": -37534627,
     "core": false,
     "deleted": false,
+    "deleted_records": [
+        {
+            "$ref": "http://1j&Gsun*"
+        }
+    ],
     "department": [
         "id nisi magna irure sunt",
         "adipisicing labore cillum"

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -78,6 +78,20 @@
     "control_number": 36418374,
     "deadline_date": "dddd-dd-dd",
     "deleted": false,
+    "deleted_records": [
+        {
+            "$ref": "http://13iAhHNVr}"
+        },
+        {
+            "$ref": "http://14=~O"
+        },
+        {
+            "$ref": "http://1"
+        },
+        {
+            "$ref": "http://14ii6"
+        }
+    ],
     "description": "qui sit Duis",
     "experiments": [
         {

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -27,6 +27,17 @@
     ],
     "control_number": -43117562,
     "deleted": true,
+    "deleted_records": [
+        {
+            "$ref": "http://14C+"
+        },
+        {
+            "$ref": "http://1lzUT5\"p~7X"
+        },
+        {
+            "$ref": "http://1h`f+ojz"
+        }
+    ],
     "history": "est",
     "issn": [
         {


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/619212/

INCOMPATIBLE adds the `deleted_records` key to all the schemas,
while previously it was only in HEP.