### PR TITLE
Auto-generated Schemas documentation 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,19 @@ from __future__ import print_function
 import os
 
 from autosemver.packaging import get_changelog, get_current_version
+from jsonschema2rst.parser_runner import run_parser
+
+
+def _generate_schemas_doc():
+    schemas_folder = os.path.join(
+        os.pardir,
+        'inspire_schemas'
+    )
+    rst_output = 'schemas'
+    run_parser(schemas_folder, rst_output)
+
+
+_generate_schemas_doc()
 
 if not os.path.exists('_build/html/_static'):
     os.makedirs('_build/html/_static')
@@ -36,6 +49,7 @@ with open('_build/html/_static/CHANGELOG.txt', 'w') as changelog_fd:
         project_dir='..',
         bugtracker_url='https://github.com/inspirehep/inspire-schemas/issues/',
     ))
+
 
 # -- General configuration ------------------------------------------------
 
@@ -54,6 +68,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -135,6 +150,10 @@ todo_include_todos = False
 # -- Options for HTML output ----------------------------------------------
 html_theme = 'alabaster'
 
+
+# Add any paths that contain custom themes here, relative to this directory.
+# html_theme_path = ['_static']
+
 html_theme_options = {
     'description': 'INSPIREHEP schemas and related tools bundle.',
     'github_user': 'inspirehep',
@@ -154,7 +173,7 @@ html_theme_options = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -178,7 +197,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['resources']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,18 @@ this part of the documentation is for you.
    api
    utils
 
+
+Schemas Reference
+-----------------
+
+Auto-generated documentation for Inspirehep schemas.
+
+.. toctree::
+   :maxdepth: 1
+
+   schemas/index
+
+
 Additional Notes
 ----------------
 

--- a/docs/resources/custom.css
+++ b/docs/resources/custom.css
@@ -1,0 +1,48 @@
+
+@import url("alabaster.css");
+
+/* -- page layout ----------------------------------------------------------- */
+
+a {
+    text-decoration: none;
+}
+
+h1 {
+    font-style: bold;
+}
+
+h1 > a {
+    color: #2f4c7c;
+}
+
+h2 > a {
+    color: #53565b;
+}
+
+.title {
+    font-size: 1.25em;
+    color: #4c77b2;
+    padding-bottom: 15px;
+    padding-top: 15px;
+}
+
+.sub-title {
+    padding-bottom: 10px;
+    padding-top: 20px;
+    font-size: 1.1em;
+    color: #3b4c84;
+}
+
+
+
+body {counter-reset: h2}
+.body h2 {counter-reset: h3}
+.body h3 {counter-reset: h4}
+.body h4 {counter-reset: h5}
+.body h5 {counter-reset: h6}
+.body h2:before {counter-increment: h2; content: counter(h2) ". "}
+.body h3:before {counter-increment: h3; content: counter(h2) "." counter(h3) ". "}
+.body h4:before {counter-increment: h4; content: counter(h2) "." counter(h3) "." counter(h4) ". "}
+.body h5:before {counter-increment: h5; content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) ". "}
+.body h6:before {counter-increment: h6; content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". "}
+h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before, h6.nocount:before {content: ""; counter-increment: none}

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -1112,6 +1112,7 @@ properties:
                             of ``773``.
 
                         This is useful when:
+
                         - there are variants in the way this publication is cited,
                         - an error was present, has been fixed, but should be preserved
                             in order to find the record.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
+jsonschema2rst
 Sphinx>=1.4.2
 -r requirements-build.txt

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def _generate_json_schemas():
         _yaml2json(yaml_file=yaml_file, json_file=json_file)
 
 
-def do_setup(url=URL):
+def do_setup():
     _generate_json_schemas()
     setup(
         author='CERN',


### PR DESCRIPTION
This PR integrate the project jsonschema2rst inside inspire-schemas, allowing to auto generate schemas-documentation on the fly. The generated docs in linked by the main documentation page.