### PR TITLE
builder: `copyright.material` is not really populated

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -663,7 +663,7 @@ class LiteratureBuilder(object):
                 copyright[key] = locals()[key]
 
         if material is not None:
-            copyright[key] = material.lower()
+            copyright['material'] = material.lower()
 
         self._append_to('copyright', copyright)
 

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -65,9 +65,10 @@
    "citeable":true,
    "copyright":[
       {
-         "url":"visual production",
+         "url":"http://copyright.web.cern.ch/",
          "holder":"cern",
-         "statement":"As stated in our Privacy Policy, Cern believes strongly in the values of privacy and transparency"
+         "statement":"As stated in our Privacy Policy, Cern believes strongly in the values of privacy and transparency",
+         "material":"publication"
       }
    ],
    "inspire_categories":[

--- a/tests/integration/fixtures/input_data_hep.yaml
+++ b/tests/integration/fixtures/input_data_hep.yaml
@@ -63,5 +63,6 @@
       "type_of_isbn":"online"
       }
      ],
-  "book_volume":"Doppler phase 2"
+  "book_volume":"Doppler phase 2",
+  "material":"publication"
 }


### PR DESCRIPTION
* Adds sample date to `material` field of `input_data_hep.yaml`.
* Adds `copyright.material` sample data to `expected_data_hep.yaml`.
* Fix wrong `url` sample to `copyright.url`.
* Fix: populate `copyright.material` field in `LiteratureBuilder`.

Closes #155 
Relates to https://github.com/inspirehep/hepcrawl/issues/128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>