### PR TITLE
builder: support `copyright.year` field

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -645,7 +645,8 @@ class LiteratureBuilder(object):
         material=None,
         holder=None,
         statement=None,
-        url=None
+        url=None,
+        year=None
     ):
         """Add Copyright.
 
@@ -656,6 +657,8 @@ class LiteratureBuilder(object):
         :type statement: string
 
         :type url: string
+
+        :type year: int
         """
         copyright = {}
         for key in ('holder', 'statement', 'url'):
@@ -664,6 +667,9 @@ class LiteratureBuilder(object):
 
         if material is not None:
             copyright['material'] = material.lower()
+
+        if year is not None:
+            copyright['year'] = int(year)
 
         self._append_to('copyright', copyright)
 

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -68,7 +68,8 @@
          "url":"http://copyright.web.cern.ch/",
          "holder":"cern",
          "statement":"As stated in our Privacy Policy, Cern believes strongly in the values of privacy and transparency",
-         "material":"publication"
+         "material":"publication",
+         "year":2010
       }
    ],
    "inspire_categories":[

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -130,6 +130,7 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     builder.add_document_type(document_type=input_data_hep['document_type'])
     builder.add_copyright(
         material=input_data_hep['material'],
+        year=input_data_hep['year'],
         holder=input_data_hep['holder'],
         statement=input_data_hep['statement'],
         url=input_data_hep['copyright_url']


### PR DESCRIPTION
* Adds `copyright.year` field to tests.
* Adds missing `copyright.year` field to the `builders.add_copyright`.

Closes #157 

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>