### PR TITLE
builder: support `dois.material` field

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -170,7 +170,7 @@ class LiteratureBuilder(object):
         self.set_citeable(True)
 
     @filter_empty_parameters
-    def add_doi(self, doi, source=None):
+    def add_doi(self, doi, source=None, material=None):
         """Add doi.
 
         :param doi: doi for the current document.
@@ -178,12 +178,21 @@ class LiteratureBuilder(object):
 
         :param source: source for the doi.
         :type source: string
+
+        :param material: material for the doi.
+        :type material: string
         """
-        if idutils.normalize_doi(doi):
-            self._append_to('dois', {
-                'value': doi,
-                'source': self._get_source(source),
-            })
+        if not idutils.normalize_doi(doi):
+            return
+
+        dois = {
+            'value': doi,
+            'source': self._get_source(source)
+        }
+        if material is not None:
+            dois['material'] = material
+
+        self._append_to('dois', dois)
 
     @filter_empty_parameters
     def add_author(self, author):

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -98,6 +98,7 @@
    "withdrawn":true,
    "dois":[
       {
+         "material":"publication",
          "source":"submitter",
          "value":"10.1088/0004-637X/715/1/51"
       }

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -63,6 +63,7 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     )
     builder.add_doi(
         doi=input_data_hep['doi'],
+        material=input_data_hep['material']
     )
     author = builder.make_author(
         full_name=input_data_hep['full_name'],


### PR DESCRIPTION
* Adds `dois.material` field to tests.
* Adds: support for `dois.material` field in `LiteratureBuilder`.

Closes #159
Relates to https://github.com/inspirehep/hepcrawl/issues/128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>