### PR TITLE
builder: support `license.material`, `license.imposing` fields

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -470,7 +470,13 @@ class LiteratureBuilder(object):
         self._append_to('languages', language)
 
     @filter_empty_parameters
-    def add_license(self, url=None, license=None):
+    def add_license(
+        self,
+        url=None,
+        license=None,
+        material=None,
+        imposing=None
+    ):
         """Add license.
 
         :param url: url for the description of the license
@@ -478,9 +484,15 @@ class LiteratureBuilder(object):
 
         :param license: license type
         :type license: string
+
+        :param material: material type
+        :type material: string
+
+        :param imposing: imposing type
+        :type imposing: string
         """
         hep_license = {}
-        for key in ('url', 'license'):
+        for key in ('url', 'license', 'material', 'imposing'):
             if locals()[key] is not None:
                 hep_license[key] = locals()[key]
 

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -122,7 +122,9 @@
    "license":[
       {
          "url":"https://opensource.org/licenses/MIT",
-         "license":"MIT"
+         "license":"MIT",
+         "material":"publication",
+         "imposing":"arXiv"
       }
    ],
    "collaborations":[

--- a/tests/integration/fixtures/input_data_hep.yaml
+++ b/tests/integration/fixtures/input_data_hep.yaml
@@ -64,5 +64,6 @@
       }
      ],
   "book_volume":"Doppler phase 2",
-  "material":"publication"
+  "material":"publication",
+  "license_imposing":"arXiv"
 }

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -103,7 +103,9 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     builder.add_language(language=input_data_hep['language'])
     builder.add_license(
         url=input_data_hep['license_url'],
-        license=input_data_hep['license']
+        license=input_data_hep['license'],
+        imposing=input_data_hep['license_imposing'],
+        material=input_data_hep['material']
     )
     builder.add_public_note(
         public_note=input_data_hep['public_note']


### PR DESCRIPTION
* Adds `license.material` field to tests.
* Adds `license.imposing` field to tests.
* Adds: support for `license.material` field.
* Adds: support for `license.imposing` field.

Closes #161
Relates to https://github.com/inspirehep/hepcrawl/issues/128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>