### PR TITLE
builder: support `publication_info.material` field

### DIFF
--- a/inspire_schemas/builders.py
+++ b/inspire_schemas/builders.py
@@ -350,6 +350,7 @@ class LiteratureBuilder(object):
         journal_title=None,
         journal_volume=None,
         pubinfo_freetext=None,
+        material=None
     ):
         """Add publication info.
 
@@ -383,11 +384,14 @@ class LiteratureBuilder(object):
         :param pubinfo_freetext: Unstructured text describing the publication
         information.
         :type pubinfo_freetext: string
+
+        :param material: material of the article
+        :type material: string
         """
         publication_item = {}
         for key in ('cnum', 'artid', 'page_end', 'page_start',
                     'journal_issue', 'journal_title',
-                    'journal_volume', 'year', 'pubinfo_freetext'):
+                    'journal_volume', 'year', 'pubinfo_freetext', 'material'):
             if locals()[key] is not None:
                 publication_item[key] = locals()[key]
 

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -48,7 +48,8 @@
          "artid":"159",
          "year":2010,
          "page_start":"58",
-         "journal_issue":"1"
+         "journal_issue":"1",
+         "material":"publication"
       }
    ],
    "title_translations":[

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -87,7 +87,8 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
         page_start=input_data_hep['page_start'],
         journal_issue=input_data_hep['journal_issue'],
         journal_title=input_data_hep['journal_title'],
-        journal_volume=input_data_hep['journal_volume']
+        journal_volume=input_data_hep['journal_volume'],
+        material=input_data_hep['material']
     )
     builder.add_preprint_date(
         preprint_date=input_data_hep['preprint_date']


### PR DESCRIPTION
* Adds `publication_info.material` field to tests.
* Adds: support for `publication.material` field.

Closes #164 
Relates to https://github.com/inspirehep/hepcrawl/issues/128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>