### PR TITLE
schemas: legacy_creation_date is not a date-time

### DIFF
--- a/inspire_schemas/records/authors.yml
+++ b/inspire_schemas/records/authors.yml
@@ -118,7 +118,7 @@ properties:
         type: array
         uniqueItems: true
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     name:
         additionalProperties: false

--- a/inspire_schemas/records/conferences.yml
+++ b/inspire_schemas/records/conferences.yml
@@ -143,7 +143,7 @@ properties:
         type: array
         uniqueItems: true
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     new_record:
         $ref: elements/json_reference.json

--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -267,7 +267,7 @@ properties:
         type: array
         uniqueItems: true
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     long_name:
         description: |-

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -949,7 +949,7 @@ properties:
             :MARC: ``961__x``
 
             Only present if the record already existed on legacy Inspire.
-        format: date-time
+        format: date
         title: Date of record creation on legacy
         type: string
     license:

--- a/inspire_schemas/records/institutions.yml
+++ b/inspire_schemas/records/institutions.yml
@@ -124,7 +124,7 @@ properties:
     legacy_ICN:
         type: string
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     location:
         additionalProperties: false

--- a/inspire_schemas/records/jobs.yml
+++ b/inspire_schemas/records/jobs.yml
@@ -101,7 +101,7 @@ properties:
         type: array
         uniqueItems: true
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     new_record:
         $ref: elements/json_reference.json

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -67,7 +67,7 @@ properties:
         type: array
         uniqueItems: true
     legacy_creation_date:
-        format: date-time
+        format: date
         type: string
     license:
         enum:


### PR DESCRIPTION
* Fixes bug in `legacy_creation_date` by replacing `date-time` format
with `date`.

Signed-off-by: Micha Moskovic <michamos@gmail.com>