### PR TITLE
elements/id: remove wikipedia pattern

### DIFF
--- a/inspire_schemas/records/elements/id.yml
+++ b/inspire_schemas/records/elements/id.yml
@@ -265,7 +265,6 @@ anyOf:
                 Non-English Wikipedia pages can be referenced by prepending the language.
 
                 :example: ``it:Fabiola_Gianotti``
-            pattern: ^[\w\-':]+$
             type: string
     required:
     - schema


### PR DESCRIPTION
The pattern restricting Wikipedia page names was wrong. The actual rules for what is a valid wikipedia
page name are at
https://en.wikipedia.org/wiki/Wikipedia:Page_name#Technical_restrictions_and_limitations,
but this is too complex to implement as a pattern.

Signed-off-by: Micha Moskovic <michamos@gmail.com>