### PR TITLE
institutions: don't require institution_hierarchy

### DIFF
--- a/inspire_schemas/records/institutions.yml
+++ b/inspire_schemas/records/institutions.yml
@@ -276,6 +276,5 @@ properties:
         uniqueItems: true
 required:
 - ICN
-- institution_hierarchy
 title: A record representing an Institution
 type: object


### PR DESCRIPTION
* Many legacy records don't have a `110__a` or `110__b`, so they would
end up with an empty `institution_hierarchy`.
* Closes #183.

Signed-off-by: Micha Moskovic <michamos@gmail.com>