### PR TITLE
experiments: make room for legacy accelerators

### DIFF
--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -184,11 +184,6 @@ properties:
             If ``experiment`` is present in :ref:`project_type`, this field
             contains information about this experiment.
         properties:
-            legacy_name:
-                description: |-
-                    :MARC: ``119__a``
-                    :example: ``CERN-LHC-CMS``
-                type: string
             short_name:
                 description: |-
                     :MARC: ``119__d``
@@ -269,6 +264,12 @@ properties:
     legacy_creation_date:
         format: date
         type: string
+    legacy_name:
+        description: |-
+            :MARC: ``119__a``
+            :example: ``CERN-LHC-CMS``
+        title: project identifier on legacy INSPIRE
+        type: string
     long_name:
         description: |-
             :MARC: ``245__a``
@@ -293,7 +294,8 @@ properties:
         title: Record replacing this one
     project_type:
         description: |-
-            :MARC: Not present, only ``experiments`` had records.
+            :MARC: ``980:ACCELERATOR`` corresponds to an ``accelerator``, otherwise
+                it is an ``experiment``.
 
             A project can represent a combination of ``collaboration``, ``accelerator`` and ``experiment``,
             depending on the contents of this field. Typical cases are:

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -67,7 +67,6 @@
     ],
     "description": "ex officia nostrud irure",
     "experiment": {
-        "legacy_name": "laboris",
         "short_name": "dolore enim et fugiat sed",
         "value": "eiusmod nisi consectetur"
     },
@@ -126,6 +125,7 @@
         }
     ],
     "legacy_creation_date": "3224-06-22T02:25:18.800Z",
+    "legacy_name": "laboris",
     "long_name": "qui esse",
     "name_variants": [
         "et minim",


### PR DESCRIPTION
* INCOMPATIBLE Moves `legacy_name` to top-level in order to take into
account that not only experiments, but also accelerators can have a
`legacy_name`.
* Also documents how to spot an `accelerator`.

Signed-off-by: Micha Moskovic <michamos@gmail.com>