### PR TITLE
experiments: relax constraints on required fields

### DIFF
--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -1,14 +1,5 @@
 $schema: http://json-schema.org/schema#
 additionalProperties: false
-dependencies:
-    project_type:
-        anyOf:
-        -   required:
-            - collaboration
-        -   required:
-            - experiment
-        -   required:
-            - accelerator
 description: |-
     This record can describe different types of projects, depending on the
     value of :ref:`experiments.json#/properties/project_type`.


### PR DESCRIPTION
* Since #187, `legacy_names` has moved out of `experiment`, so that
field can be empty now.

Signed-off-by: Micha Moskovic <michamos@gmail.com>