### PR TITLE
Revert "id: adding support for OSTI"

### DIFF
--- a/inspire_schemas/records/elements/id.yml
+++ b/inspire_schemas/records/elements/id.yml
@@ -287,19 +287,3 @@ anyOf:
     - value
     title: SLAC identifier
     type: object
--   additionalProperties: false
-    properties:
-        schema:
-            enum:
-            - OSTI
-            type: string
-        value:
-            description: |-
-                :example: ``123456``
-            pattern: ^\d+$
-            type: string
-    required:
-    - schema
-    - value
-    title: OSTI identifier
-    type: object


### PR DESCRIPTION
This reverts commit 8f6159d7cbf075654b0702a793509336f3928d4a.

No records are affected so it's not incompatible.

(OSTI is not for id.yml, which is for HepNames, for Literature)