### PR TITLE
Fixed initials parsing

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -31,7 +31,7 @@ from functools import wraps
 
 import idutils
 
-from ..utils import normalize_author_name_with_comma, validate
+from ..utils import normalize_author_name, validate
 
 EMPTIES = [None, '', [], {}]
 
@@ -232,7 +232,7 @@ class LiteratureBuilder(object):
 
         author = {}
 
-        author['full_name'] = normalize_author_name_with_comma(full_name)
+        author['full_name'] = normalize_author_name(full_name)
 
         if affiliations is not None:
             author = _add_affiliations(author, affiliations)

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def do_setup():
             'autosemver',
             'jsonschema',
             'idutils',
+            'nameparser',
             'pyyaml',
             'six',
         ],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -191,3 +191,46 @@ def test_split_pubnote():
     expected = 'J.Testing', '42', '1', '45', None
 
     assert expected == result
+
+
+def test_normalize_author_name_full():
+
+    expected = 'Smith, John Peter'
+
+    assert expected == utils.normalize_author_name('Smith, John Peter')
+
+
+def test_normalize_author_name_first_initial():
+
+    expected = 'Smith, J. Peter'
+
+    assert expected == utils.normalize_author_name('Smith, J Peter')
+    assert expected == utils.normalize_author_name('Smith, J. Peter')
+    assert expected == utils.normalize_author_name('Smith, J. Peter ')
+
+
+def test_normalize_author_name_middle_initial():
+
+    expected = 'Smith, John P.'
+
+    assert expected == utils.normalize_author_name('Smith, John P.')
+    assert expected == utils.normalize_author_name('Smith, John P. ')
+    assert expected == utils.normalize_author_name('Smith, John P ')
+
+
+def test_normalize_author_name_with_dots_initials():
+
+    expected = 'Smith, J.P.'
+
+    assert expected == utils.normalize_author_name('Smith, J. P.')
+    assert expected == utils.normalize_author_name('Smith, J.P.')
+    assert expected == utils.normalize_author_name('Smith, J.P. ')
+    assert expected == utils.normalize_author_name('Smith, J. P. ')
+
+
+def test_normalize_author_name_with_spaces():
+
+    expected = 'Smith, J.P.'
+
+    assert expected == utils.normalize_author_name('Smith, J P ')
+    assert expected == utils.normalize_author_name('Smith, J P')


### PR DESCRIPTION
When importing an article from CrossRef, if the author's name contains initials
each followed by a space, they would be displayed as one word, appendend
together.

The requirement I enforce ensures that a dot is appended after each initial for
readability.