### PR TITLE
journals: attempt to finalize schema

### DIFF
--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -173,7 +173,7 @@ properties:
             parent_report_number:
                 description: |-
                     :MARC: ``999C5r`` but not distinguished from the cited
-                        document :ref:`reference.json#/properties/report_number`.
+                        document :ref:`reference.json#/properties/report_numbers`.
                 type: string
             parent_title:
                 description: |-

--- a/inspire_schemas/records/elements/related_record.yml
+++ b/inspire_schemas/records/elements/related_record.yml
@@ -9,16 +9,17 @@ properties:
     record:
         $ref: json_reference.json
         description: |-
-            :MARC: ``510__0`` (for Institutions and Experiments),
-                ``78002/78502/78708w`` (for Literature and Journals).
+            :MARC: ``510__0`` (for Institutions and Experiments), ``530__0``
+                (for Journals), ``78002/78502/78708w`` (for Literature).
         title: URL of related record
     relation:
         description: |-
             The possible values are:
 
             ``predecessor``
-                :MARC: ``510__w:a`` (if not a Literature record) or the field
-                    comes from ``78002`` (for Literature).
+                :MARC: ``510__w:a`` (for Institutions and Experiments),
+                    ``530__w:a`` (for Journals) or the field comes from
+                    ``78002`` (for Literature).
 
                 The related record is a predecessor of the current one, i.e.
                 the current record supersedes the related one.
@@ -74,8 +75,8 @@ properties:
         type: string
     relation_freetext:
         description: |-
-            :MARC: ``510__i`` (for Institutions and Experiments) or ``79708i`` (for
-                Literature and Journals).
+            :MARC: ``510__i`` (for Institutions and Experiments), ``530__i``
+                (for Journals) or ``78708i`` (for Literature).
 
             If none of the standard relations in :ref:`relation` fit, a textual
             relation can alternatively be provided here.

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -5,104 +5,281 @@ properties:
         format: url
         type: string
     _collections:
+        description: |-
+            Used by `invenio-collections` to store the collections this record
+            belongs to.
+
+            .. note::
+
+                This field is maintained by `invenio-collections` and should
+                not be edited manually.
         items:
             type: string
+        title: '`invenio-collections` metadata'
         type: array
+    _harvesting_info:
+        additionalProperties: false
+        description: |-
+            :MARC: ``583``
+
+            Metadata about the harvesting process of this journal.
+        properties:
+            coverage:
+                description: |-
+                    :MARC: ``583__a``
+
+                    Whether all articles are automatically added to Inspire
+                    (``full``) or a selection is made (``partial``).
+                enum:
+                - full
+                - partial
+                type: string
+            date_last_harvest:
+                description: |-
+                    :MARC: ``583__c``
+
+                    Date on which the most recent harvest was performed.
+
+                    .. note::
+
+                        This date does not necessarily mean that any records
+                        were created on that day. This can happen if there was
+                        no journal update since the previous time, or that the
+                        update did not have any relevant effect for Inspire.
+                format: date
+                type: string
+            last_seen_item:
+                description: |-
+                    :MARC: ``583__3``
+
+                    Information about last processed item in the harvest. This
+                    item can be a volume, an issue or even a specific article.
+                type: string
+            method:
+                description: |-
+                    :MARC: ``583__i``
+
+                    How the harvesting is performed. Possible values are:
+
+                    ``feed``
+                        Inspire receives a feed with publisher updates.
+
+                    ``harvest``
+                        harvesting is done through webscraping.
+
+                    ``print``
+                        articles are picked manually from the printed journal.
+
+                    ``hepcrawl``
+                        harvesting is done through a native ``hepcrawl`` spider.
+                enum:
+                - feed
+                - harvest
+                - print
+                - hepcrawl
+                type: string
+        type: object
     _private_notes:
+        description: |-
+            :MARC: ``595__a``, ``667__x``
+
+            These notes are only visible to privileged users, not regular
+            users.
         items:
             $ref: elements/sourced_value.json
+        title: List of private notes
         type: array
         uniqueItems: true
-    coden:
-        items:
-            pattern: ^[0-9\.A-Z_-]{4,6}$
-            title: CODEN
-            type: string
-        title: CODEN
-        type: array
-        uniqueItems: true
+    book_series:
+        description: |-
+            :MARC: ``980__a:BookSeries`` corresponds to ``true``
+
+            Whether this “journal” is actually a serial whose volumes are
+            books, i.e. a book series.
+        type: boolean
     control_number:
+        description: |-
+            :MARC: ``001``
+
+            Read-only field.
+        title: ID of current record
         type: integer
+    date_ended:
+        description: |-
+            :MARC: Not present.
+
+            Date of last publication of the journal.
+        format: date
+        type: string
+    date_started:
+        description: |-
+            :MARC: Not present.
+
+            Date of first publication of the journal.
+        format: date
+        type: string
     deleted:
+        description: |-
+            :MARC: ``980__a/c:deleted``
+        title: Whether this record has been deleted
         type: boolean
     deleted_records:
         description: |-
-            List of deleted records referring to this record
+            :MARC: ``981__a``
+
+            List of records that were deleted because they were replaced by
+            this one. This typically happens when merging two records: one of
+            them gets enriched with the information of the other one, which is
+            then superfluous and gets deleted.
+
+            For the opposite concept, see :ref:`new_record`.
         items:
             $ref: elements/json_reference.json
-        title: Deleted Records
         type: array
-    history:
-        title: History
-        type: string
-    issn:
+    doi_prefixes:
+        description: |-
+            :MARC: ``677__d``
+
+            This DOI prefix is the common start of DOIs in this journals, that
+            all articles share.
+
+            .. note::
+                This is a list because journals can change publishers, and the
+                new publisher will often assign new DOIs in its own prefix.
+        items:
+            pattern: ^10\.\d+(\.\d+)?/.*$
+            type: string
+        title: List of DOI prefixes for this journal
+        type: array
+    inspire_categories:
+        items:
+            $ref: elements/inspire_field.json
+        title: List of Inspire categories
+        type: array
+        uniqueItems: true
+    issns:
+        description: |-
+            :MARC: ``022``
         items:
             additionalProperties: false
             properties:
-                comment:
-                    description: |-
-                        Further information about type.
-                    type: string
                 medium:
                     description: |-
-                        Medium (type) of the ISSN.
+                        :MARC: ``022__b``
                     enum:
                     - online
                     - print
+                    title: Physical medium to which this ISSN refers
                     type: string
                 value:
+                    description: |-
+                        :MARC: ``022__a``
+                        :example: ``0295-5075``
                     pattern: ^\d{4}-\d{3}[\dX]$
                     type: string
             required:
             - value
             type: object
+        title: List of ISSNs
         type: array
         uniqueItems: true
-    journal_handling:
-        title: Journal handling
-        type: string
-    journal_titles:
-        items:
-            $ref: elements/title.json
-        type: array
-        uniqueItems: true
+    journal_title:
+        $ref: elements/title.json
+        description: |-
+            :MARC: ``130``
     legacy_creation_date:
+        description: |-
+            :MARC: ``961__x``
+
+            Only present if the record already existed on legacy Inspire.
         format: date
+        title: Date of record creation on legacy
         type: string
     license:
-        enum:
-        - probably
-        - it
-        - is
-        - needed
-        title: License
-        type: string
-    license_urls:
-        items:
-            $ref: elements/url.json
-        type: array
-        uniqueItems: true
+        additionalProperties: false
+        description: |-
+            :MARC: ``540``
+        properties:
+            license:
+                description: |-
+                    :MARC: ``540__a``
+
+                    Either the short name of the license or the full
+                    license statement.
+
+                    :example: ``CC-BY-4.0``
+                title: License statement
+                type: string
+            url:
+                description: |-
+                    :MARC: ``540__u``
+
+                    URL where the full license statement may be found, if
+                    only a short name is provided in ``license``.
+                format: url
+                title: URL of the license
+                type: string
+        type: object
     new_record:
         $ref: elements/json_reference.json
         description: |-
-            Master record that replaces this record
-        title: New record
-    peer_reviewed:
-        title: Is the journal peer-reviewed?
+            :MARC: ``970__d``
+
+            Contains a reference to the record replacing the current one, if it
+            is marked as :ref:`deleted`.
+        title: Record replacing this one
+    proceedings:
+        description: |-
+            :MARC: ``690__a:Proceedings`` corresponds to ``true``
+
+            Whether this journal publishes conference proceedings. If it
+            publishes both conference proceedings and peer reviewed articles
+            (depending on issue), both this field and :ref:`refereed` are
+            ``true``.
         type: boolean
     public_notes:
+        description: |-
+            :MARC: ``500__a``, ``640__a``, ``680__i``
+
+            Any notes about the document that do not fit into another field.
+
+            .. note::
+
+                These notes are publicly visible. For notes not shown to
+                regular users, see :ref:`_private_notes`.
         items:
             $ref: elements/sourced_value.json
+        title: List of public notes
         type: array
         uniqueItems: true
     publisher:
+        description: |-
+            :MARC: ``643__b``
+
+            The first element of the list is the current publisher of the journal.
+
+            .. note::
+                This is a list because journals can change publishers.
         items:
             type: string
-        title: Publisher
+        title: List of publishers
         type: array
+    refereed:
+        description: |-
+            :MARC: ``690__a:Peer review`` corresponds to ``true``,
+                ``690__a:NON-PUBLISHED`` to ``false``
+
+            Whether this journal is considered to perform peer review. This
+            assessment might differ from the journal's.
+
+            If the journal does not publish proceedings :ref:`proceedings`, all
+            articles in it are flagged as :ref:`hep.json#/properties/refereed`.
+            Otherwise, it is only the case if the article is not a ``conference
+            paper``.
+        type: boolean
     related_records:
         description: |-
-            :MARC: ``78002``, ``78502``
+            :MARC: ``530``
         items:
             $ref: elements/related_record.json
         title: List of related records
@@ -110,17 +287,25 @@ properties:
         uniqueItems: true
     self:
         $ref: elements/json_reference.json
+    short_title:
         description: |-
-            Url of the record itself
-        title: Url of the record
-    short_titles:
-        items:
-            $ref: elements/title.json
-        type: array
-        uniqueItems: true
+            :MARC: ``711__a``
+
+            Normalized title of the journal
+
+            :example: ``Phys.Rev. D``
+        type: string
     title_variants:
+        description: |-
+            :MARC: ``730__a``
+
+            These name variants appear in references and are used to properly
+            recognize citations.
+
+            :example: ``PHYS REVIEW``
         items:
-            $ref: elements/title.json
+            type: string
+        title: List of journal name variants
         type: array
         uniqueItems: true
     urls:
@@ -128,5 +313,5 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
-title: Journal
+title: A record representing a Journal
 type: object

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -1,196 +1,124 @@
 {
     "_collections": [
-        "enim irure eu nulla",
-        "aliquip",
-        "sed ex exercitation Ut",
-        "cupidatat"
+        "nisi adipisicing",
+        "velit non labore consectetur eiusmod",
+        "qui",
+        "consequat commodo sit elit Lorem"
     ],
+    "_harvesting_info": {
+        "coverage": "partial",
+        "date_last_harvest": "8529-64-08",
+        "last_seen_item": "fugiat ullamco sit",
+        "method": "print"
+    },
     "_private_notes": [
         {
-            "source": "adipisicing commodo consequat",
-            "value": "est aliquip"
+            "source": "non",
+            "value": "cupidatat ut"
         },
         {
-            "source": "dolor ea id",
-            "value": "qui ut dolor Excepteur sit"
+            "source": "ex sit sed",
+            "value": "aute incididunt velit adipisicing"
         },
         {
-            "source": "nostrud Duis",
-            "value": "voluptate a"
+            "source": "veniam anim sed exercitation adipisicing",
+            "value": "eu fugiat"
+        },
+        {
+            "source": "qui laborum adipisicing reprehenderit",
+            "value": "irure"
+        },
+        {
+            "source": "quis cupidatat esse",
+            "value": "proident incididunt"
         }
     ],
-    "coden": [
-        "7LJZ8",
-        "204CH",
-        "7QHLWK",
-        ".5ZW",
-        "6DXMO"
-    ],
-    "control_number": 1669676,
+    "book_series": false,
+    "control_number": 37182727,
+    "date_ended": "6705-97-36",
+    "date_started": "2970-01-87",
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1j!87[p*ahU"
+            "$ref": "http://18:R0OU"
         },
         {
-            "$ref": "http://1VE3"
-        },
-        {
-            "$ref": "http://1t'[]wj"
+            "$ref": "http://1iMc3p~/N(7"
         }
     ],
-    "history": "consectetur",
-    "issn": [
+    "doi_prefixes": [
+        "10.0027/dX0bFjrj.S",
+        "10.5053241.8297337446/\">?(z &+X?"
+    ],
+    "inspire_categories": [
         {
-            "comment": "eiusmod nisi enim deserunt laborum",
+            "source": "magpie",
+            "term": "General Physics"
+        }
+    ],
+    "issns": [
+        {
             "medium": "print",
-            "value": "1435-0492"
-        },
-        {
-            "comment": "et consequat",
-            "medium": "print",
-            "value": "3019-4547"
-        },
-        {
-            "comment": "sint ea dolor",
-            "medium": "online",
-            "value": "5532-9021"
-        },
-        {
-            "comment": "consectetur te",
-            "medium": "online",
-            "value": "4845-8198"
-        },
-        {
-            "comment": "voluptate laboris",
-            "medium": "online",
-            "value": "6321-1792"
+            "value": "8937-6658"
         }
     ],
-    "journal_handling": "quis enim commodo",
-    "journal_titles": [
-        {
-            "source": "amet",
-            "subtitle": "irure",
-            "title": "Lorem"
-        },
-        {
-            "source": "incididunt en",
-            "subtitle": "ad deserunt est culpa voluptate",
-            "title": "dolor aute amet"
-        }
-    ],
-    "legacy_creation_date": "3275-12-15T15:22:00.357Z",
-    "license": "it",
-    "license_urls": [
-        {
-            "description": "exercitation dolore",
-            "value": "http://1cu&[Bo#"
-        },
-        {
-            "description": "proident",
-            "value": "http://1i81+."
-        }
-    ],
-    "new_record": {
-        "$ref": "http://1L3Qf@e"
+    "journal_title": {
+        "source": "quis",
+        "subtitle": "est",
+        "title": "irure laborum in labore ut"
     },
-    "peer_reviewed": true,
+    "legacy_creation_date": "0090-21-56",
+    "license": {
+        "license": "in exercitation",
+        "url": "http://1U"
+    },
+    "new_record": {
+        "$ref": "http://1"
+    },
+    "proceedings": false,
     "public_notes": [
         {
-            "source": "enim",
-            "value": "Duis"
+            "source": "cillum in",
+            "value": "sunt in"
         },
         {
-            "source": "ipsum consequat ad quis",
-            "value": "exercitation consectetur off"
+            "source": "culpa sint",
+            "value": "commodo cillum ex minim elit"
         },
         {
-            "source": "ex",
-            "value": "exercitation nulla ea eiusmod dolore"
-        },
-        {
-            "source": "eiusmod consequat",
-            "value": "sit laborum eu qui"
+            "source": "commodo culpa",
+            "value": "in nostrud"
         }
     ],
     "publisher": [
-        "proident eu",
-        "est ullamco Duis labore",
-        "Ut veniam Duis",
-        "mollit laborum",
-        "consequat sit"
+        "fugiat anim ad aliqua labore",
+        "anim qui officia"
     ],
+    "refereed": false,
     "related_records": [
         {
+            "curated_relation": true,
             "record": {
-                "$ref": "http://1b"
+                "$ref": "http://1"
             },
-            "relation": "commented"
+            "relation": "predecessor",
+            "relation_freetext": "et tempor"
         }
     ],
     "self": {
-        "$ref": "http://1lk#P"
+        "$ref": "http://14\\\\["
     },
-    "short_titles": [
-        {
-            "source": "amet veniam nisi minim commodo",
-            "subtitle": "incididunt labore in qui eu",
-            "title": "sed Ut in"
-        },
-        {
-            "source": "nulla",
-            "subtitle": "quis am",
-            "title": "Ut"
-        },
-        {
-            "source": "eiusmod fugiat aute id",
-            "subtitle": "dolor non",
-            "title": "consectetur ut amet consequat occaecat"
-        },
-        {
-            "source": "incididunt",
-            "subtitle": "voluptate aute non eiusmod ad",
-            "title": "ea quis dolore ullamco"
-        }
-    ],
+    "short_title": "irure labore ipsum quis velit",
     "title_variants": [
-        {
-            "source": "exercitation veniam dolor",
-            "subtitle": "do deserunt qui cillum",
-            "title": "tempor est"
-        },
-        {
-            "source": "reprehenderit mollit tempor ea",
-            "subtitle": "nostrud dolor anim",
-            "title": "fugiat Excep"
-        },
-        {
-            "source": "quis aliqua",
-            "subtitle": "proident irure est qui veniam",
-            "title": "irure ut"
-        }
+        "inci",
+        "dolore ea dolore sed",
+        "esse veniam occaecat do incididunt",
+        "amet magna et"
     ],
     "urls": [
         {
-            "description": "in",
-            "value": "http://1"
-        },
-        {
-            "description": "enim sint",
-            "value": "http://1i!rbO(#\"k"
-        },
-        {
-            "description": "incididunt sed",
-            "value": "http://1uv*Vgi?4c"
-        },
-        {
-            "description": "in elit non",
-            "value": "http://1qw9w(x5"
-        },
-        {
-            "description": "consequat id enim sunt magna",
-            "value": "http://1V,D/']Hv5"
+            "description": "exercitation elit Ut sint magna",
+            "value": "http://1 %6AON5m"
         }
     ]
 }


### PR DESCRIPTION
This is a draft for the new journal schema. Any comments welcome.

The generated documentation now appears [here](http://inspire-schemas.readthedocs.io/en/docstests/schemas/records/journals.html).

@inspirehep/inspire-content (in particular @fschwenn and @cleggm1)

This is a continuation of PR #215.