### PR TITLE
element/references: allow several report_numbers

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -253,8 +253,8 @@ class ReferenceBuilder(object):
             self._ensure_reference_field('arxiv_eprint',
                                          _normalize_arxiv(repno))
         else:
-            self._ensure_reference_field('publication_info', {})
-            self.obj['reference']['report_number'] = repno
+            self._ensure_reference_field('report_numbers', [])
+            self.obj['reference']['report_numbers'].append(repno)
 
     def add_uid(self, uid):
         """Add unique identifier in correct field."""

--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -189,7 +189,7 @@ properties:
                 minimum: 1000
                 type: integer
         type: object
-    report_number:
+    report_numbers:
         description: |-
             :MARC: ``999C5r``
 
@@ -197,7 +197,10 @@ properties:
 
                 If the cited document is only part of a report, use
                 :ref:`publication_info/properties/parent_report_number` instead.
-        type: string
+        items:
+            type: string
+        type: array
+        uniqueItems: true
     texkey:
         description: |-
             :MARC: ``999C5k``

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1032,7 +1032,9 @@
                     "parent_title": "",
                     "year": 1698
                 },
-                "report_number": "tempor nulla adipisicing consectetur",
+                "report_numbers": [
+                    "tempor nulla adipisicing consectetur"
+                ],
                 "texkey": "ullamco dolor esse quis",
                 "title": {
                     "source": "reprehenderit nisi ut non nulla",
@@ -1150,7 +1152,9 @@
                     "parent_title": "exercitation",
                     "year": 1983
                 },
-                "report_number": "dolore et",
+                "report_numbers": [
+                    "dolore et"
+                ],
                 "texkey": "voluptate Excepteur ",
                 "title": {
                     "source": "aliquip incididunt irure",
@@ -1282,7 +1286,9 @@
                     "parent_title": "officia elit magna irure",
                     "year": 1565
                 },
-                "report_number": "commodo",
+                "report_numbers": [
+                    "commodo"
+                ],
                 "texkey": "non laboris do aliqua ullamco",
                 "title": {
                     "source": "dolor",

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -574,6 +574,31 @@ def test_set_publisher():
     assert expected == result
 
 
+def test_add_report_number_handles_several_report_numbers():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.add_report_number('CMS-B2G-17-001')
+    builder.add_report_number('CERN-EP-2017-184')
+
+    expected = [
+        {
+            'reference': {
+                'report_numbers': [
+                    'CMS-B2G-17-001',
+                    'CERN-EP-2017-184',
+                ],
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 def test_add_report_number_handles_arxiv_ids():
     schema = load_schema('hep')
     subschema = schema['properties']['references']


### PR DESCRIPTION
* INCOMPATIBLE `report_numbers` is now an array instead of the
`report_number` string. This is needed as sometimes more than one report
number appears in a single reference. Closes #209.

Signed-off-by: Micha Moskovic <michamos@gmail.com>