### PR TITLE
Suffixes taken into account for name normalization

### DIFF
--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -540,6 +540,17 @@ properties:
             type: string
         type: array
         uniqueItems: true
+    curated:
+        description: |-
+            :MARC: `500__a` containing `*Temporary entry*`, `*Temporary
+                record*` or `*Brief entry*` correspond to `false`, otherwise it
+                is `true`.
+
+            Whether this record has been curated by a human, to ensure the
+            quality standards of Inspire. Records having the :ref:`core` flag
+            are all curated eventually, whereas non-core records are
+            not systematically curated.
+        type: boolean
     deleted:
         description: |-
             :MARC: ``980__a/c:deleted``

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -31,6 +31,7 @@ import six
 from jsonschema import validate as jsonschema_validate
 from jsonschema import RefResolver, draft4_format_checker
 from nameparser import HumanName
+from nameparser.config import Constants
 from pkg_resources import resource_filename
 from unidecode import unidecode
 
@@ -221,21 +222,42 @@ def normalize_author_name(author):
 
     :return name: the name of the author normilized
     """
+    constants = Constants()
+    roman_numeral_suffixes = [u'v', u'vi', u'vii', u'viii', u'ix', u'x',
+                              u'xii', u'xiii', u'xiv', u'xv']
+    for suff in roman_numeral_suffixes:
+        constants.suffix_not_acronyms.add(suff)
+
     def _is_initial(author_name):
-        return len(author_name) == 1 or '.' in author_name
+        return len(author_name) == 1 or u'.' in author_name
 
     def _ensure_dotted_initials(author_name):
-        if _is_initial(author_name) and '.' not in author_name:
+        if _is_initial(author_name)\
+                and u'.' not in author_name:
             seq = (author_name, u'.')
             author_name = u''.join(seq)
         return author_name
 
-    name = HumanName(author)
+    def _ensure_dotted_suffixes(author_suffix):
+        if u'.' not in author_suffix:
+            seq = (author_suffix, u'.')
+            author_suffix = u''.join(seq)
+        return author_suffix
+
+    def _is_roman_numeral(suffix):
+        """Controls that the userinput only contains valid roman numerals"""
+        validRomanNumerals = [u'M', u'D', u'C', u'L', u'X',
+                              u'V', u'I', u'(', u')']
+        return all(letters in validRomanNumerals
+                   for letters in suffix.upper())
+
+    name = HumanName(author, constants=constants)
 
     name.first = _ensure_dotted_initials(name.first)
     name.middle = _ensure_dotted_initials(name.middle)
 
-    if _is_initial(name.first) and _is_initial(name.middle):
+    if _is_initial(name.first) \
+       and _is_initial(name.middle):
         normalized_names = u'{first_name}{middle_name}'
     else:
         normalized_names = u'{first_name} {middle_name}'
@@ -245,8 +267,13 @@ def normalize_author_name(author):
         middle_name=name.middle,
     )
 
+    if _is_roman_numeral(name.suffix):
+        suffix = name.suffix.upper()
+    else:
+        suffix = _ensure_dotted_suffixes(name.suffix)
+
     final_name = u', '.join(
-        part for part in (name.last, normalized_names.rstrip()) if part
-    ).strip()
+        part for part in (name.last, normalized_names.rstrip(), suffix)
+        if part)
 
     return final_name

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -245,9 +245,8 @@ def normalize_author_name(author):
         middle_name=name.middle,
     )
 
-    normalized_names.strip()
     final_name = u', '.join(
-        part for part in (name.last, normalized_names) if part
+        part for part in (name.last, normalized_names.rstrip()) if part
     ).strip()
 
     return final_name

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -685,6 +685,7 @@
         "fugiat officia irure in Ut",
         "sit enim sint ea"
     ],
+    "curated": true,
     "deleted": false,
     "deleted_records": [
         {

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -256,3 +256,17 @@ def test_normalize_author_name_handles_unicode():
     expected = u'蕾拉'
 
     assert expected == utils.normalize_author_name(u'蕾拉')
+
+
+@pytest.mark.parametrize("input_author_name,expected", [
+    ('Smith, John Jr', 'Smith, John, Jr.'),
+    ('Smith, John Jr.', 'Smith, John, Jr.'),
+    ('Smith, John III', 'Smith, John, III'),
+    ('Smith, John iii', 'Smith, John, III'),
+    ('Smith, John VIII', 'Smith, John, VIII'),
+    ('Smith, John viii', 'Smith, John, VIII'),
+    ('Smith, John IV', 'Smith, John, IV'),
+    ('Smith, John iv', 'Smith, John, IV'),
+])
+def test_normalize_author_name_handles_suffixes(input_author_name, expected):
+    assert utils.normalize_author_name(input_author_name) == expected


### PR DESCRIPTION
Modified the name normalization function in order to deal with suffixes in the specified way. It takes into account unicode characters as well. However, titles are still not being dealt with.