### PR TITLE
journals: require journal and short titles

### DIFF
--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -313,5 +313,8 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
+required:
+- journal_title
+- short_title
 title: A record representing a Journal
 type: object


### PR DESCRIPTION
* INCOMPATIBLE `journal_title` and `short_title` are now required.

Signed-off-by: Micha Moskovic <michamos@gmail.com>