### PR TITLE
Change 'submission_number' field to 'holdingpen_record'

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -31,7 +31,7 @@ from functools import wraps
 
 import idutils
 
-from ..utils import normalize_author_name_with_comma, validate
+from ..utils import normalize_author_name, validate
 
 EMPTIES = [None, '', [], {}]
 
@@ -232,7 +232,7 @@ class LiteratureBuilder(object):
 
         author = {}
 
-        author['full_name'] = normalize_author_name_with_comma(full_name)
+        author['full_name'] = normalize_author_name(full_name)
 
         if affiliations is not None:
             author = _add_affiliations(author, affiliations)

--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -612,7 +612,7 @@ class LiteratureBuilder(object):
         self,
         method,
         date=None,
-        submission_number=None,
+        holdingpen_record=None,
         internal_uid=None,
         email=None,
         orcid=None,
@@ -621,7 +621,7 @@ class LiteratureBuilder(object):
     ):
         """Add acquisition source.
 
-        :type submission_number: integer
+        :type holdingpen_record: string
 
         :type email: integer
 
@@ -655,7 +655,7 @@ class LiteratureBuilder(object):
 
         acquisition_source = {}
 
-        acquisition_source['submission_number'] = str(submission_number)
+        acquisition_source['holdingpen_record'] = holdingpen_record
         acquisition_source['source'] = self._get_source(source)
         for key in ('datetime', 'email', 'method', 'orcid', 'internal_uid'):
             if locals()[key] is not None:

--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -253,8 +253,8 @@ class ReferenceBuilder(object):
             self._ensure_reference_field('arxiv_eprint',
                                          _normalize_arxiv(repno))
         else:
-            self._ensure_reference_field('publication_info', {})
-            self.obj['reference']['report_number'] = repno
+            self._ensure_reference_field('report_numbers', [])
+            self.obj['reference']['report_numbers'].append(repno)
 
     def add_uid(self, uid):
         """Add unique identifier in correct field."""

--- a/inspire_schemas/records/elements/acquisition_source.yml
+++ b/inspire_schemas/records/elements/acquisition_source.yml
@@ -40,7 +40,7 @@ properties:
             `submitter`
                 when obtained from a user submission. In this case, `orcid`,
                 `internal_uid` and `email` store identifiers of the submitter,
-                and `submission_number` an ID of the submission.
+                and `holdingpen_record` a json_reference to the holdingpen record.
 
             `oai`
                 when obtained by OAI-PMH harvesting.
@@ -68,12 +68,10 @@ properties:
         type: string
     source:
         $ref: source.json
-    submission_number:
+    holdingpen_record:
         description: |-
             :MARC: ``541__e``
-
-            This only gets populated when `method` is `submitter`.
-        title: Holding pen record ID of the submission
+        title: json_reference to the holdingpen record.
         type: string
 title: Origin of the metadata in the record
 type: object

--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -189,7 +189,7 @@ properties:
                 minimum: 1000
                 type: integer
         type: object
-    report_number:
+    report_numbers:
         description: |-
             :MARC: ``999C5r``
 
@@ -197,7 +197,10 @@ properties:
 
                 If the cited document is only part of a report, use
                 :ref:`publication_info/properties/parent_report_number` instead.
-        type: string
+        items:
+            type: string
+        type: array
+        uniqueItems: true
     texkey:
         description: |-
             :MARC: ``999C5k``

--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -173,7 +173,7 @@ properties:
             parent_report_number:
                 description: |-
                     :MARC: ``999C5r`` but not distinguished from the cited
-                        document :ref:`reference.json#/properties/report_number`.
+                        document :ref:`reference.json#/properties/report_numbers`.
                 type: string
             parent_title:
                 description: |-

--- a/inspire_schemas/records/elements/related_record.yml
+++ b/inspire_schemas/records/elements/related_record.yml
@@ -9,16 +9,17 @@ properties:
     record:
         $ref: json_reference.json
         description: |-
-            :MARC: ``510__0`` (for Institutions and Experiments),
-                ``78002/78502/78708w`` (for Literature and Journals).
+            :MARC: ``510__0`` (for Institutions and Experiments), ``530__0``
+                (for Journals), ``78002/78502/78708w`` (for Literature).
         title: URL of related record
     relation:
         description: |-
             The possible values are:
 
             ``predecessor``
-                :MARC: ``510__w:a`` (if not a Literature record) or the field
-                    comes from ``78002`` (for Literature).
+                :MARC: ``510__w:a`` (for Institutions and Experiments),
+                    ``530__w:a`` (for Journals) or the field comes from
+                    ``78002`` (for Literature).
 
                 The related record is a predecessor of the current one, i.e.
                 the current record supersedes the related one.
@@ -74,8 +75,8 @@ properties:
         type: string
     relation_freetext:
         description: |-
-            :MARC: ``510__i`` (for Institutions and Experiments) or ``79708i`` (for
-                Literature and Journals).
+            :MARC: ``510__i`` (for Institutions and Experiments), ``530__i``
+                (for Journals) or ``78708i`` (for Literature).
 
             If none of the standard relations in :ref:`relation` fit, a textual
             relation can alternatively be provided here.

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -540,6 +540,17 @@ properties:
             type: string
         type: array
         uniqueItems: true
+    curated:
+        description: |-
+            :MARC: `500__a` containing `*Temporary entry*`, `*Temporary
+                record*` or `*Brief entry*` correspond to `false`, otherwise it
+                is `true`.
+
+            Whether this record has been curated by a human, to ensure the
+            quality standards of Inspire. Records having the :ref:`core` flag
+            are all curated eventually, whereas non-core records are
+            not systematically curated.
+        type: boolean
     deleted:
         description: |-
             :MARC: ``980__a/c:deleted``

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -5,104 +5,281 @@ properties:
         format: url
         type: string
     _collections:
+        description: |-
+            Used by `invenio-collections` to store the collections this record
+            belongs to.
+
+            .. note::
+
+                This field is maintained by `invenio-collections` and should
+                not be edited manually.
         items:
             type: string
+        title: '`invenio-collections` metadata'
         type: array
+    _harvesting_info:
+        additionalProperties: false
+        description: |-
+            :MARC: ``583``
+
+            Metadata about the harvesting process of this journal.
+        properties:
+            coverage:
+                description: |-
+                    :MARC: ``583__a``
+
+                    Whether all articles are automatically added to Inspire
+                    (``full``) or a selection is made (``partial``).
+                enum:
+                - full
+                - partial
+                type: string
+            date_last_harvest:
+                description: |-
+                    :MARC: ``583__c``
+
+                    Date on which the most recent harvest was performed.
+
+                    .. note::
+
+                        This date does not necessarily mean that any records
+                        were created on that day. This can happen if there was
+                        no journal update since the previous time, or that the
+                        update did not have any relevant effect for Inspire.
+                format: date
+                type: string
+            last_seen_item:
+                description: |-
+                    :MARC: ``583__3``
+
+                    Information about last processed item in the harvest. This
+                    item can be a volume, an issue or even a specific article.
+                type: string
+            method:
+                description: |-
+                    :MARC: ``583__i``
+
+                    How the harvesting is performed. Possible values are:
+
+                    ``feed``
+                        Inspire receives a feed with publisher updates.
+
+                    ``harvest``
+                        harvesting is done through webscraping.
+
+                    ``print``
+                        articles are picked manually from the printed journal.
+
+                    ``hepcrawl``
+                        harvesting is done through a native ``hepcrawl`` spider.
+                enum:
+                - feed
+                - harvest
+                - print
+                - hepcrawl
+                type: string
+        type: object
     _private_notes:
+        description: |-
+            :MARC: ``595__a``, ``667__x``
+
+            These notes are only visible to privileged users, not regular
+            users.
         items:
             $ref: elements/sourced_value.json
+        title: List of private notes
         type: array
         uniqueItems: true
-    coden:
-        items:
-            pattern: ^[0-9\.A-Z_-]{4,6}$
-            title: CODEN
-            type: string
-        title: CODEN
-        type: array
-        uniqueItems: true
+    book_series:
+        description: |-
+            :MARC: ``980__a:BookSeries`` corresponds to ``true``
+
+            Whether this “journal” is actually a serial whose volumes are
+            books, i.e. a book series.
+        type: boolean
     control_number:
+        description: |-
+            :MARC: ``001``
+
+            Read-only field.
+        title: ID of current record
         type: integer
+    date_ended:
+        description: |-
+            :MARC: Not present.
+
+            Date of last publication of the journal.
+        format: date
+        type: string
+    date_started:
+        description: |-
+            :MARC: Not present.
+
+            Date of first publication of the journal.
+        format: date
+        type: string
     deleted:
+        description: |-
+            :MARC: ``980__a/c:deleted``
+        title: Whether this record has been deleted
         type: boolean
     deleted_records:
         description: |-
-            List of deleted records referring to this record
+            :MARC: ``981__a``
+
+            List of records that were deleted because they were replaced by
+            this one. This typically happens when merging two records: one of
+            them gets enriched with the information of the other one, which is
+            then superfluous and gets deleted.
+
+            For the opposite concept, see :ref:`new_record`.
         items:
             $ref: elements/json_reference.json
-        title: Deleted Records
         type: array
-    history:
-        title: History
-        type: string
-    issn:
+    doi_prefixes:
+        description: |-
+            :MARC: ``677__d``
+
+            This DOI prefix is the common start of DOIs in this journals, that
+            all articles share.
+
+            .. note::
+                This is a list because journals can change publishers, and the
+                new publisher will often assign new DOIs in its own prefix.
+        items:
+            pattern: ^10\.\d+(\.\d+)?/.*$
+            type: string
+        title: List of DOI prefixes for this journal
+        type: array
+    inspire_categories:
+        items:
+            $ref: elements/inspire_field.json
+        title: List of Inspire categories
+        type: array
+        uniqueItems: true
+    issns:
+        description: |-
+            :MARC: ``022``
         items:
             additionalProperties: false
             properties:
-                comment:
-                    description: |-
-                        Further information about type.
-                    type: string
                 medium:
                     description: |-
-                        Medium (type) of the ISSN.
+                        :MARC: ``022__b``
                     enum:
                     - online
                     - print
+                    title: Physical medium to which this ISSN refers
                     type: string
                 value:
+                    description: |-
+                        :MARC: ``022__a``
+                        :example: ``0295-5075``
                     pattern: ^\d{4}-\d{3}[\dX]$
                     type: string
             required:
             - value
             type: object
+        title: List of ISSNs
         type: array
         uniqueItems: true
-    journal_handling:
-        title: Journal handling
-        type: string
-    journal_titles:
-        items:
-            $ref: elements/title.json
-        type: array
-        uniqueItems: true
+    journal_title:
+        $ref: elements/title.json
+        description: |-
+            :MARC: ``130``
     legacy_creation_date:
+        description: |-
+            :MARC: ``961__x``
+
+            Only present if the record already existed on legacy Inspire.
         format: date
+        title: Date of record creation on legacy
         type: string
     license:
-        enum:
-        - probably
-        - it
-        - is
-        - needed
-        title: License
-        type: string
-    license_urls:
-        items:
-            $ref: elements/url.json
-        type: array
-        uniqueItems: true
+        additionalProperties: false
+        description: |-
+            :MARC: ``540``
+        properties:
+            license:
+                description: |-
+                    :MARC: ``540__a``
+
+                    Either the short name of the license or the full
+                    license statement.
+
+                    :example: ``CC-BY-4.0``
+                title: License statement
+                type: string
+            url:
+                description: |-
+                    :MARC: ``540__u``
+
+                    URL where the full license statement may be found, if
+                    only a short name is provided in ``license``.
+                format: url
+                title: URL of the license
+                type: string
+        type: object
     new_record:
         $ref: elements/json_reference.json
         description: |-
-            Master record that replaces this record
-        title: New record
-    peer_reviewed:
-        title: Is the journal peer-reviewed?
+            :MARC: ``970__d``
+
+            Contains a reference to the record replacing the current one, if it
+            is marked as :ref:`deleted`.
+        title: Record replacing this one
+    proceedings:
+        description: |-
+            :MARC: ``690__a:Proceedings`` corresponds to ``true``
+
+            Whether this journal publishes conference proceedings. If it
+            publishes both conference proceedings and peer reviewed articles
+            (depending on issue), both this field and :ref:`refereed` are
+            ``true``.
         type: boolean
     public_notes:
+        description: |-
+            :MARC: ``500__a``, ``640__a``, ``680__i``
+
+            Any notes about the document that do not fit into another field.
+
+            .. note::
+
+                These notes are publicly visible. For notes not shown to
+                regular users, see :ref:`_private_notes`.
         items:
             $ref: elements/sourced_value.json
+        title: List of public notes
         type: array
         uniqueItems: true
     publisher:
+        description: |-
+            :MARC: ``643__b``
+
+            The first element of the list is the current publisher of the journal.
+
+            .. note::
+                This is a list because journals can change publishers.
         items:
             type: string
-        title: Publisher
+        title: List of publishers
         type: array
+    refereed:
+        description: |-
+            :MARC: ``690__a:Peer review`` corresponds to ``true``,
+                ``690__a:NON-PUBLISHED`` to ``false``
+
+            Whether this journal is considered to perform peer review. This
+            assessment might differ from the journal's.
+
+            If the journal does not publish proceedings :ref:`proceedings`, all
+            articles in it are flagged as :ref:`hep.json#/properties/refereed`.
+            Otherwise, it is only the case if the article is not a ``conference
+            paper``.
+        type: boolean
     related_records:
         description: |-
-            :MARC: ``78002``, ``78502``
+            :MARC: ``530``
         items:
             $ref: elements/related_record.json
         title: List of related records
@@ -110,17 +287,25 @@ properties:
         uniqueItems: true
     self:
         $ref: elements/json_reference.json
+    short_title:
         description: |-
-            Url of the record itself
-        title: Url of the record
-    short_titles:
-        items:
-            $ref: elements/title.json
-        type: array
-        uniqueItems: true
+            :MARC: ``711__a``
+
+            Normalized title of the journal
+
+            :example: ``Phys.Rev. D``
+        type: string
     title_variants:
+        description: |-
+            :MARC: ``730__a``
+
+            These name variants appear in references and are used to properly
+            recognize citations.
+
+            :example: ``PHYS REVIEW``
         items:
-            $ref: elements/title.json
+            type: string
+        title: List of journal name variants
         type: array
         uniqueItems: true
     urls:
@@ -128,5 +313,5 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
-title: Journal
+title: A record representing a Journal
 type: object

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -313,5 +313,8 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
+required:
+- journal_title
+- short_title
 title: A record representing a Journal
 type: object

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -226,8 +226,8 @@ def normalize_author_name(author):
 
     def _ensure_dotted_initials(author_name):
         if _is_initial(author_name) and '.' not in author_name:
-            seq = (author_name, '.')
-            author_name = ''.join(seq)
+            seq = (author_name, u'.')
+            author_name = u''.join(seq)
         return author_name
 
     name = HumanName(author)
@@ -236,9 +236,9 @@ def normalize_author_name(author):
     name.middle = _ensure_dotted_initials(name.middle)
 
     if _is_initial(name.first) and _is_initial(name.middle):
-        normalized_names = '{first_name}{middle_name}'
+        normalized_names = u'{first_name}{middle_name}'
     else:
-        normalized_names = '{first_name} {middle_name}'
+        normalized_names = u'{first_name} {middle_name}'
 
     normalized_names = normalized_names.format(
         first_name=name.first,
@@ -246,7 +246,7 @@ def normalize_author_name(author):
     )
 
     normalized_names.strip()
-    final_name = ', '.join(
+    final_name = u', '.join(
         part for part in (name.last, normalized_names) if part
     ).strip()
 

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -31,6 +31,7 @@ import six
 from jsonschema import validate as jsonschema_validate
 from jsonschema import RefResolver, draft4_format_checker
 from pkg_resources import resource_filename
+from unidecode import unidecode
 
 from six.moves.urllib.parse import urlsplit
 
@@ -50,9 +51,12 @@ def split_page_artid(page_artid):
     if not page_artid:
         return None, None, None
 
+    # normalize unicode dashes
+    page_artid = unidecode(six.text_type(page_artid))
+
     if '-' in page_artid:
         # if it has a dash it's a page range
-        page_range = page_artid.split('-')
+        page_range = page_artid.replace('--', '-').split('-')
         if len(page_range) == 2:
             page_start, page_end = page_range
         else:

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ def do_setup():
             'idutils',
             'pyyaml',
             'six',
+            'unidecode',
         ],
         license='GPLv2',
         name='inspire-schemas',

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def do_setup():
             'autosemver',
             'jsonschema',
             'idutils',
+            'nameparser',
             'pyyaml',
             'six',
             'unidecode',

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -27,11 +27,11 @@
     "acquisition_source": {
         "datetime": "2234-06-08T05:46:05.263Z",
         "email": "rLmoeWrC4fI6iZ@IBfNPyIlR.vwp",
+        "holdingpen_record": "voluptate reprehenderit nisi nostrud elit",
         "internal_uid": 76120453,
         "method": "submitter",
         "orcid": "8351-4483-7418-2367",
-        "source": "voluptate qui fugiat nulla",
-        "submission_number": "voluptate reprehenderit nisi nostrud elit"
+        "source": "voluptate qui fugiat nulla"
     },
     "advisors": [
         {

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -120,7 +120,7 @@
       "email":"albert.einstein@hep.edu",
       "source":"submitter",
       "internal_uid":1,
-      "submission_number":"12",
+      "holdingpen_record":"/holdingpen/12",
       "orcid":"0000-0001-8528-2091",
       "method":"batchuploader"
    },

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1032,7 +1032,9 @@
                     "parent_title": "",
                     "year": 1698
                 },
-                "report_number": "tempor nulla adipisicing consectetur",
+                "report_numbers": [
+                    "tempor nulla adipisicing consectetur"
+                ],
                 "texkey": "ullamco dolor esse quis",
                 "title": {
                     "source": "reprehenderit nisi ut non nulla",
@@ -1150,7 +1152,9 @@
                     "parent_title": "exercitation",
                     "year": 1983
                 },
-                "report_number": "dolore et",
+                "report_numbers": [
+                    "dolore et"
+                ],
                 "texkey": "voluptate Excepteur ",
                 "title": {
                     "source": "aliquip incididunt irure",
@@ -1282,7 +1286,9 @@
                     "parent_title": "officia elit magna irure",
                     "year": 1565
                 },
-                "report_number": "commodo",
+                "report_numbers": [
+                    "commodo"
+                ],
                 "texkey": "non laboris do aliqua ullamco",
                 "title": {
                     "source": "dolor",

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -685,6 +685,7 @@
         "fugiat officia irure in Ut",
         "sit enim sint ea"
     ],
+    "curated": true,
     "deleted": false,
     "deleted_records": [
         {

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -137,11 +137,11 @@
     "acquisition_source": {
         "datetime": "4655-08-10T13:24:39.377Z",
         "email": "YMD@FNozTaLqsdeiHRpHEe.gmlg",
+        "holdingpen_record": "Lorem ad reprehenderit sed esse",
         "internal_uid": 33119180,
         "method": "submitter",
         "orcid": "7517-2459-3361-8685",
-        "source": "do occaecat voluptate elit veniam",
-        "submission_number": "Lorem ad reprehenderit sed esse"
+        "source": "do occaecat voluptate elit veniam"
     },
     "arxiv_eprints": [
         {

--- a/tests/integration/fixtures/input_data_hep.yaml
+++ b/tests/integration/fixtures/input_data_hep.yaml
@@ -36,7 +36,7 @@
    "report_number":"7892",
    "collaboration":"Mexico City U., Cuajimalpa",
    "method":"batchuploader",
-   "submission_number":"12",
+   "holdingpen_record":"/holdingpen/12",
    "internal_uid":1,
    "email":"albert.einstein@hep.edu",
    "orcid":"0000-0001-8528-2091",

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -1,196 +1,124 @@
 {
     "_collections": [
-        "enim irure eu nulla",
-        "aliquip",
-        "sed ex exercitation Ut",
-        "cupidatat"
+        "nisi adipisicing",
+        "velit non labore consectetur eiusmod",
+        "qui",
+        "consequat commodo sit elit Lorem"
     ],
+    "_harvesting_info": {
+        "coverage": "partial",
+        "date_last_harvest": "8529-64-08",
+        "last_seen_item": "fugiat ullamco sit",
+        "method": "print"
+    },
     "_private_notes": [
         {
-            "source": "adipisicing commodo consequat",
-            "value": "est aliquip"
+            "source": "non",
+            "value": "cupidatat ut"
         },
         {
-            "source": "dolor ea id",
-            "value": "qui ut dolor Excepteur sit"
+            "source": "ex sit sed",
+            "value": "aute incididunt velit adipisicing"
         },
         {
-            "source": "nostrud Duis",
-            "value": "voluptate a"
+            "source": "veniam anim sed exercitation adipisicing",
+            "value": "eu fugiat"
+        },
+        {
+            "source": "qui laborum adipisicing reprehenderit",
+            "value": "irure"
+        },
+        {
+            "source": "quis cupidatat esse",
+            "value": "proident incididunt"
         }
     ],
-    "coden": [
-        "7LJZ8",
-        "204CH",
-        "7QHLWK",
-        ".5ZW",
-        "6DXMO"
-    ],
-    "control_number": 1669676,
+    "book_series": false,
+    "control_number": 37182727,
+    "date_ended": "6705-97-36",
+    "date_started": "2970-01-87",
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1j!87[p*ahU"
+            "$ref": "http://18:R0OU"
         },
         {
-            "$ref": "http://1VE3"
-        },
-        {
-            "$ref": "http://1t'[]wj"
+            "$ref": "http://1iMc3p~/N(7"
         }
     ],
-    "history": "consectetur",
-    "issn": [
+    "doi_prefixes": [
+        "10.0027/dX0bFjrj.S",
+        "10.5053241.8297337446/\">?(z &+X?"
+    ],
+    "inspire_categories": [
         {
-            "comment": "eiusmod nisi enim deserunt laborum",
+            "source": "magpie",
+            "term": "General Physics"
+        }
+    ],
+    "issns": [
+        {
             "medium": "print",
-            "value": "1435-0492"
-        },
-        {
-            "comment": "et consequat",
-            "medium": "print",
-            "value": "3019-4547"
-        },
-        {
-            "comment": "sint ea dolor",
-            "medium": "online",
-            "value": "5532-9021"
-        },
-        {
-            "comment": "consectetur te",
-            "medium": "online",
-            "value": "4845-8198"
-        },
-        {
-            "comment": "voluptate laboris",
-            "medium": "online",
-            "value": "6321-1792"
+            "value": "8937-6658"
         }
     ],
-    "journal_handling": "quis enim commodo",
-    "journal_titles": [
-        {
-            "source": "amet",
-            "subtitle": "irure",
-            "title": "Lorem"
-        },
-        {
-            "source": "incididunt en",
-            "subtitle": "ad deserunt est culpa voluptate",
-            "title": "dolor aute amet"
-        }
-    ],
-    "legacy_creation_date": "3275-12-15T15:22:00.357Z",
-    "license": "it",
-    "license_urls": [
-        {
-            "description": "exercitation dolore",
-            "value": "http://1cu&[Bo#"
-        },
-        {
-            "description": "proident",
-            "value": "http://1i81+."
-        }
-    ],
-    "new_record": {
-        "$ref": "http://1L3Qf@e"
+    "journal_title": {
+        "source": "quis",
+        "subtitle": "est",
+        "title": "irure laborum in labore ut"
     },
-    "peer_reviewed": true,
+    "legacy_creation_date": "0090-21-56",
+    "license": {
+        "license": "in exercitation",
+        "url": "http://1U"
+    },
+    "new_record": {
+        "$ref": "http://1"
+    },
+    "proceedings": false,
     "public_notes": [
         {
-            "source": "enim",
-            "value": "Duis"
+            "source": "cillum in",
+            "value": "sunt in"
         },
         {
-            "source": "ipsum consequat ad quis",
-            "value": "exercitation consectetur off"
+            "source": "culpa sint",
+            "value": "commodo cillum ex minim elit"
         },
         {
-            "source": "ex",
-            "value": "exercitation nulla ea eiusmod dolore"
-        },
-        {
-            "source": "eiusmod consequat",
-            "value": "sit laborum eu qui"
+            "source": "commodo culpa",
+            "value": "in nostrud"
         }
     ],
     "publisher": [
-        "proident eu",
-        "est ullamco Duis labore",
-        "Ut veniam Duis",
-        "mollit laborum",
-        "consequat sit"
+        "fugiat anim ad aliqua labore",
+        "anim qui officia"
     ],
+    "refereed": false,
     "related_records": [
         {
+            "curated_relation": true,
             "record": {
-                "$ref": "http://1b"
+                "$ref": "http://1"
             },
-            "relation": "commented"
+            "relation": "predecessor",
+            "relation_freetext": "et tempor"
         }
     ],
     "self": {
-        "$ref": "http://1lk#P"
+        "$ref": "http://14\\\\["
     },
-    "short_titles": [
-        {
-            "source": "amet veniam nisi minim commodo",
-            "subtitle": "incididunt labore in qui eu",
-            "title": "sed Ut in"
-        },
-        {
-            "source": "nulla",
-            "subtitle": "quis am",
-            "title": "Ut"
-        },
-        {
-            "source": "eiusmod fugiat aute id",
-            "subtitle": "dolor non",
-            "title": "consectetur ut amet consequat occaecat"
-        },
-        {
-            "source": "incididunt",
-            "subtitle": "voluptate aute non eiusmod ad",
-            "title": "ea quis dolore ullamco"
-        }
-    ],
+    "short_title": "irure labore ipsum quis velit",
     "title_variants": [
-        {
-            "source": "exercitation veniam dolor",
-            "subtitle": "do deserunt qui cillum",
-            "title": "tempor est"
-        },
-        {
-            "source": "reprehenderit mollit tempor ea",
-            "subtitle": "nostrud dolor anim",
-            "title": "fugiat Excep"
-        },
-        {
-            "source": "quis aliqua",
-            "subtitle": "proident irure est qui veniam",
-            "title": "irure ut"
-        }
+        "inci",
+        "dolore ea dolore sed",
+        "esse veniam occaecat do incididunt",
+        "amet magna et"
     ],
     "urls": [
         {
-            "description": "in",
-            "value": "http://1"
-        },
-        {
-            "description": "enim sint",
-            "value": "http://1i!rbO(#\"k"
-        },
-        {
-            "description": "incididunt sed",
-            "value": "http://1uv*Vgi?4c"
-        },
-        {
-            "description": "in elit non",
-            "value": "http://1qw9w(x5"
-        },
-        {
-            "description": "consequat id enim sunt magna",
-            "value": "http://1V,D/']Hv5"
+            "description": "exercitation elit Ut sint magna",
+            "value": "http://1 %6AON5m"
         }
     ]
 }

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -127,7 +127,7 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     builder.add_collaboration(collaboration=input_data_hep['collaboration'])
     builder.add_acquisition_source(
         method=input_data_hep['method'],
-        submission_number=input_data_hep['submission_number'],
+        holdingpen_record=input_data_hep['holdingpen_record'],
         internal_uid=input_data_hep['internal_uid'],
         email=input_data_hep['email'],
         orcid=input_data_hep['orcid']

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -574,6 +574,31 @@ def test_set_publisher():
     assert expected == result
 
 
+def test_add_report_number_handles_several_report_numbers():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.add_report_number('CMS-B2G-17-001')
+    builder.add_report_number('CERN-EP-2017-184')
+
+    expected = [
+        {
+            'reference': {
+                'report_numbers': [
+                    'CMS-B2G-17-001',
+                    'CERN-EP-2017-184',
+                ],
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 def test_add_report_number_handles_arxiv_ids():
     schema = load_schema('hep')
     subschema = schema['properties']['references']

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -200,3 +200,53 @@ def test_split_pubnote():
     expected = 'J.Testing', '42', '1', '45', None
 
     assert expected == result
+
+
+def test_normalize_author_name_full():
+    expected = 'Smith, John Peter'
+
+    assert expected == utils.normalize_author_name('Smith, John Peter')
+
+
+def test_normalize_author_name_handles_names_with_first_initial():
+    expected = 'Smith, J. Peter'
+
+    assert expected == utils.normalize_author_name('Smith, J Peter')
+    assert expected == utils.normalize_author_name('Smith, J. Peter')
+    assert expected == utils.normalize_author_name('Smith, J. Peter ')
+
+
+def test_normalize_author_name_handles_names_with_middle_initial():
+    expected = 'Smith, John P.'
+
+    assert expected == utils.normalize_author_name('Smith, John P.')
+    assert expected == utils.normalize_author_name('Smith, John P. ')
+    assert expected == utils.normalize_author_name('Smith, John P ')
+
+
+def test_normalize_author_name_handles_names_with_dots_initials():
+    expected = 'Smith, J.P.'
+
+    assert expected == utils.normalize_author_name('Smith, J. P.')
+    assert expected == utils.normalize_author_name('Smith, J.P.')
+    assert expected == utils.normalize_author_name('Smith, J.P. ')
+    assert expected == utils.normalize_author_name('Smith, J. P. ')
+
+
+def test_normalize_author_name_handles_names_with_spaces():
+    expected = 'Smith, J.P.'
+
+    assert expected == utils.normalize_author_name('Smith, J P ')
+    assert expected == utils.normalize_author_name('Smith, J P')
+
+
+def test_normalize_author_name_handles_names_with_several_last_names():
+    expected = 'Smith Davis, J.P.'
+
+    assert expected == utils.normalize_author_name('Smith Davis, J.P.')
+
+
+def test_normalize_author_name_handles_jimmy():  # http://jimmy.pink
+    expected = 'Jimmy'
+
+    assert expected == utils.normalize_author_name('Jimmy')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -250,3 +250,9 @@ def test_normalize_author_name_handles_jimmy():  # http://jimmy.pink
     expected = 'Jimmy'
 
     assert expected == utils.normalize_author_name('Jimmy')
+
+
+def test_normalize_author_name_handles_unicode():
+    expected = u'蕾拉'
+
+    assert expected == utils.normalize_author_name(u'蕾拉')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -184,6 +184,15 @@ def test_split_page_artid_artid():
     assert expected == result
 
 
+def test_split_page_artid_unicode_dash():
+    page_string = u'45−47'
+    result = utils.split_page_artid(page_string)
+
+    expected = '45', '47', None
+
+    assert expected == result
+
+
 def test_split_pubnote():
     pubnote = 'J.Testing,42,1-45'
     result = utils.split_pubnote(pubnote)


### PR DESCRIPTION
Because the 'submission_number' field is being used also in non-submissions,
I have renamed it in a more representative way. Soon, it will contain a
json_reference to the holdingpen record, thus the schema must be updated
accordingly.

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>