### PR TITLE
global: handle _collections directly

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -102,7 +102,14 @@ class LiteratureBuilder(object):
         record, in order to edit an already existent record
         :type record: dict
         """
-        self.record = {'curated': False} if record is None else record
+        if record is None:
+            self.record = {
+                '_collections': ['Literature'],
+                'curated': False,
+            }
+        else:
+            self.record = record
+
         self.source = source
 
     def _append_to(self, field, element):
@@ -781,13 +788,13 @@ class LiteratureBuilder(object):
         self.record['number_of_pages'] = number_of_pages
 
     @filter_empty_parameters
-    def add_special_collection(self, special_collection):
-        """Add special_collection.
+    def add_collection(self, collection):
+        """Add collection.
 
-        :param special_collection: defines the type of the current document
-        :type special_collection: string
+        :param collection: defines the type of the current document
+        :type collection: string
         """
-        self._append_to('special_collections', special_collection)
+        self._append_to('_collections', collection)
 
     @filter_empty_parameters
     def add_publication_type(self, publication_type):

--- a/inspire_schemas/records/authors.yml
+++ b/inspire_schemas/records/authors.yml
@@ -6,8 +6,13 @@ properties:
         type: string
     _collections:
         items:
+            enum:
+            - Authors
             type: string
+        minItems: 1
+        title: Collections to which record belongs
         type: array
+        uniqueItems: true
     _private_notes:
         items:
             $ref: elements/sourced_value.json
@@ -266,4 +271,5 @@ properties:
         uniqueItems: true
 required:
 - name
+- _collections
 type: object

--- a/inspire_schemas/records/conferences.yml
+++ b/inspire_schemas/records/conferences.yml
@@ -5,18 +5,14 @@ properties:
         format: url
         type: string
     _collections:
-        description: |-
-            Used by `invenio-collections` to store the collections this record
-            belongs to.
-
-            .. note::
-
-                This field is maintained by `invenio-collections` and should
-                not be edited manually.
         items:
+            enum:
+            - Conferences
             type: string
-        title: '`invenio-collections` metadata'
+        minItems: 1
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _private_notes:
         description: |-
             :MARC: ``595``
@@ -213,5 +209,7 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
+required:
+- _collections
 title: Conference
 type: object

--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -8,18 +8,13 @@ properties:
         format: url
         type: string
     _collections:
-        description: |-
-            Used by `invenio-collections` to store the collections this record
-            belongs to.
-
-            .. note::
-
-                This field is maintained by `invenio-collections` and should
-                not be edited manually.
         items:
+            enum:
+            - Experiments
             type: string
-        title: '`invenio-collections` metadata'
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _full_ingestion:
         title: Whether to ingest all articles written by this project
         type: boolean
@@ -354,5 +349,6 @@ properties:
         uniqueItems: true
 required:
 - project_type
+- _collections
 title: A collaboration/experiment/accelerator record
 type: object

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -6,17 +6,39 @@ properties:
         type: string
     _collections:
         description: |-
-            Used by `invenio-collections` to store the collections this record
-            belongs to.
+            :MARC: ``980__a`` (``HEP`` maps to ``Literature``)
 
-            .. note::
+            Regular Literature records have collection ``Literature`` only.
 
-                This field is maintained by `invenio-collections` and should
-                not be edited manually.
+            The other collections are used by different groups to manage
+            records using the Inspire infrastructure, but which do not belong
+            to the Inspire literature collection. If a record belongs to one
+            of these collections but not ``Literature``, it is not shown in the
+            standard search results.
         items:
+            enum:
+            - BABAR Analysis Documents
+            - BABAR Internal BAIS
+            - BABAR Internal Notes
+            - CDF Internal Notes
+            - CDF Notes
+            - CDS Hidden
+            - D0 Internal Notes
+            - D0 Preliminary Notes
+            - H1 Internal Notes
+            - H1 Preliminary Notes
+            - HAL Hidden
+            - HEP Hidden
+            - HERMES Internal Notes
+            - LArSoft Internal Notes
+            - LArSoft Notes
+            - Literature
+            - ZEUS Internal Notes
+            - ZEUS Preliminary Notes
             type: string
-        title: '`invenio-collections` metadata'
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _desy_bookkeeping:
         description: |-
             :MARC: ``595_D``
@@ -1418,38 +1440,6 @@ properties:
         uniqueItems: true
     self:
         $ref: elements/json_reference.json
-    special_collections:
-        description: |-
-            :MARC: ``980__a``
-
-            These collections are used by different groups to manage records
-            using the Inspire infrastructure, but which do not belong to
-            the Inspire literature collection.
-            If a record belongs to a special collection, it is not shown in the
-            standard search results.
-        items:
-            enum:
-            - BABAR-ANALYSIS-DOCUMENT
-            - BABAR-INTERNAL-BAIS
-            - BABAR-INTERNAL-NOTE
-            - CDF-INTERNAL-NOTE
-            - CDF-NOTE
-            - CDSHIDDEN
-            - D0-INTERNAL-NOTE
-            - D0-PRELIMINARY-NOTE
-            - H1-INTERNAL-NOTE
-            - H1-PRELIMINARY-NOTE
-            - HALHIDDEN
-            - HEPHIDDEN
-            - HERMES-INTERNAL-NOTE
-            - LARSOFT-INTERNAL-NOTE
-            - LARSOFT-NOTE
-            - ZEUS-INTERNAL-NOTE
-            - ZEUS-PRELIMINARY-NOTE
-            type: string
-        title: Special collections to which this record belongs
-        type: array
-        uniqueItems: true
     texkeys:
         description: |-
             :MARC: ``035`` with ``9:SPIRESTeX`` or ``9:INSPIRETeX``
@@ -1567,5 +1557,6 @@ properties:
 required:
 - document_type
 - titles
+- _collections
 title: A record in the Literature collection
 type: object

--- a/inspire_schemas/records/institutions.yml
+++ b/inspire_schemas/records/institutions.yml
@@ -22,18 +22,14 @@ properties:
         title: List of affiliation identifiers
         type: array
     _collections:
-        description: |-
-            Used by `invenio-collections` to store the collections this record
-            belongs to.
-
-            .. note::
-
-                This field is maintained by `invenio-collections` and should
-                not be edited manually.
         items:
+            enum:
+            - Institutions
             type: string
-        title: '`invenio-collections` metadata'
+        minItems: 1
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _private_notes:
         description: |-
             :MARC: ``595``, ``667``
@@ -274,5 +270,7 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
+required:
+- _collections
 title: A record representing an Institution
 type: object

--- a/inspire_schemas/records/jobs.yml
+++ b/inspire_schemas/records/jobs.yml
@@ -6,8 +6,13 @@ properties:
         type: string
     _collections:
         items:
+            enum:
+            - Jobs
             type: string
+        minItems: 1
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _private_notes:
         items:
             $ref: elements/sourced_value.json
@@ -152,5 +157,7 @@ properties:
             $ref: elements/url.json
         type: array
         uniqueItems: true
+required:
+- _collections
 title: HEP Job
 type: object

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -5,18 +5,14 @@ properties:
         format: url
         type: string
     _collections:
-        description: |-
-            Used by `invenio-collections` to store the collections this record
-            belongs to.
-
-            .. note::
-
-                This field is maintained by `invenio-collections` and should
-                not be edited manually.
         items:
+            enum:
+            - Journals
             type: string
-        title: '`invenio-collections` metadata'
+        minItems: 1
+        title: Collections to which this record belongs
         type: array
+        uniqueItems: true
     _harvesting_info:
         additionalProperties: false
         description: |-
@@ -316,5 +312,6 @@ properties:
 required:
 - journal_title
 - short_title
+- _collections
 title: A record representing a Journal
 type: object

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -1,6 +1,6 @@
 {
     "_collections": [
-        "sit in elit nulla in"
+        "Authors"
     ],
     "_private_notes": [
         {

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -1,8 +1,6 @@
 {
     "_collections": [
-        "non",
-        "esse est",
-        "nostrud esse amet tempor mollit"
+        "Conferences"
     ],
     "_private_notes": [
         {

--- a/tests/integration/fixtures/expected_data_hep.yaml
+++ b/tests/integration/fixtures/expected_data_hep.yaml
@@ -1,4 +1,8 @@
 {
+   "_collections":[
+      "Literature",
+      "H1 Preliminary Notes"
+   ],
    "preprint_date":"2013-06-19",
    "thesis_info":{
       "date":"2014-08-11",
@@ -39,9 +43,6 @@
             }
          ]
       }
-   ],
-   "special_collections":[
-      "H1-PRELIMINARY-NOTE"
    ],
    "titles":[
       {

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -1,10 +1,6 @@
 {
     "_collections": [
-        "et tempor Excepteur aute",
-        "nostrud ipsum non",
-        "ut culpa sit",
-        "incididunt",
-        "nisi Ut sunt"
+        "Experiments"
     ],
     "_full_ingestion": false,
     "_private_notes": [

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1,10 +1,9 @@
 {
     "_collections": [
-        "dolor eu incididunt",
-        "in in qui",
-        "consequat sint",
-        "deserunt fugiat eiusmod",
-        "reprehenderit anim aliquip aliqua dolor"
+        "D0 Internal Notes",
+        "HERMES Internal Notes",
+        "BABAR Analysis Documents",
+        "BABAR Internal BAIS"
     ],
     "_desy_bookkeeping": [
         {
@@ -1339,12 +1338,6 @@
     "self": {
         "$ref": "http://1@F|-:(pM&"
     },
-    "special_collections": [
-        "CDF-NOTE",
-        "D0-INTERNAL-NOTE",
-        "LARSOFT-INTERNAL-NOTE",
-        "H1-PRELIMINARY-NOTE"
-    ],
     "texkeys": [
         "velit magna in reprehe",
         "Duis tempor in",

--- a/tests/integration/fixtures/input_data_hep.yaml
+++ b/tests/integration/fixtures/input_data_hep.yaml
@@ -48,7 +48,7 @@
    "statement":"As stated in our Privacy Policy, Cern believes strongly in the values of privacy and transparency",
    "copyright_url":"http://copyright.web.cern.ch/",
    "number_of_pages":8,
-   "special_collection":"H1-PRELIMINARY-NOTE",
+   "collection":"H1 Preliminary Notes",
    "publication_type":"review",
    "core": true,
    "refereed":true,

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -6,9 +6,7 @@
         "consequat qui"
     ],
     "_collections": [
-        "veniam irure",
-        "ut adipisicing amet",
-        "in et enim nisi"
+        "Institutions"
     ],
     "_private_notes": [
         {

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -1,7 +1,6 @@
 {
     "_collections": [
-        "fugiat adipisicing",
-        "proident et"
+        "Jobs"
     ],
     "_private_notes": [
         {

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -1,9 +1,6 @@
 {
     "_collections": [
-        "nisi adipisicing",
-        "velit non labore consectetur eiusmod",
-        "qui",
-        "consequat commodo sit elit Lorem"
+        "Journals"
     ],
     "_harvesting_info": {
         "coverage": "partial",

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -145,8 +145,8 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     builder.add_number_of_pages(
         number_of_pages=input_data_hep['number_of_pages']
     )
-    builder.add_special_collection(
-        special_collection=input_data_hep['special_collection']
+    builder.add_collection(
+        collection=input_data_hep['collection']
     )
     builder.add_publication_type(
         publication_type=input_data_hep['publication_type']


### PR DESCRIPTION
* INCOMPATIBLE Previously, the `_collections` was not used directly, as it was
managed by inveniosoftware/invenio-collections. This required to have an
extra field, `special_collections` that was modified instead.

Signed-off-by: Micha Moskovic <michamos@gmail.com>