### PR TITLE
builders: correct __repr__ of LiteratureBuilder

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -135,7 +135,7 @@ class LiteratureBuilder(object):
 
     def __repr__(self):
         """Printable representation of the builder."""
-        return 'LiteratureBuilder(source="{}", record={})'.format(
+        return 'LiteratureBuilder(source={!r}, record={})'.format(
             self.source,
             self.record
         )

--- a/tests/unit/test_literature_builder.py
+++ b/tests/unit/test_literature_builder.py
@@ -296,3 +296,15 @@ def test_add_license_doesnt_overwrite_name_if_no_url():
 
     assert validate(result, subschema) is None
     assert expected == result
+
+
+def test_repr_handles_source_none():
+    builder = LiteratureBuilder()
+    assert repr(builder).startswith('LiteratureBuilder(source=None, record={')
+
+
+def test_repr_handles_source_present():
+    builder = LiteratureBuilder('publisher')
+    assert repr(builder).startswith(
+        "LiteratureBuilder(source='publisher', record={"
+    )


### PR DESCRIPTION
* Previously, when `source` was `None`, the quoting was incorrect.

Signed-off-by: Micha Moskovic <michamos@gmail.com>