### PR TITLE
api: validate date format

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -28,6 +28,7 @@ import os
 import re
 
 import six
+from inspire_utils.date import PartialDate
 from jsonschema import validate as jsonschema_validate
 from jsonschema import RefResolver, draft4_format_checker
 from nameparser import HumanName
@@ -432,6 +433,10 @@ def load_schema(schema_name):
     return schema_data
 
 
+inspire_format_checker = draft4_format_checker
+inspire_format_checker.checks('date', raises=ValueError)(PartialDate.loads)
+
+
 def validate(data, schema=None):
     """Validate the given dictionary against the given schema.
 
@@ -462,7 +467,7 @@ def validate(data, schema=None):
         instance=data,
         schema=schema,
         resolver=LocalRefResolver.from_schema(schema),
-        format_checker=draft4_format_checker,
+        format_checker=inspire_format_checker,
     )
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "json-schema-faker": "^0.4.1",
+        "moment": "^2.19.1"
+    }
+}

--- a/scripts/generate_example_records.js
+++ b/scripts/generate_example_records.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
-//requires the json-schema-faker npm package installed
 var fs = require('fs'),
     jsf = require('json-schema-faker'),
+    moment = require('moment'),
     path = require('path');
 
-jsf.format('date', function(gen, schema){ return gen.randexp('^\\d{4}-\\d{2}-\\d{2}$');});
+jsf.format('date', function(gen, schema){
+    var max = moment('2020-12-31', 'YYYY-MM-DD').unix()
+    var timestamp = Math.floor(Math.random() * max);
+    var date = moment.unix(timestamp);
+    return date.format('YYYY-MM-DD');
+});
 jsf.format('url', function(gen, schema){ return gen.randexp('^http://1.*$');});
 jsf.format('.+, .+', function(gen, schema){ return gen.randexp('^.+, .+$');});
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def do_setup():
             'autosemver',
             'jsonschema',
             'idutils',
+            'inspire-utils',
             'nameparser',
             'pyyaml',
             'six',

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -4,280 +4,376 @@
     ],
     "_private_notes": [
         {
-            "source": "aute",
-            "value": "ullamco"
+            "source": "do dolore",
+            "value": "ea in exercitation do ut"
         },
         {
-            "source": "officia aliquip non culpa",
-            "value": "proident"
-        },
-        {
-            "source": "ad magna",
-            "value": "amet"
-        },
-        {
-            "source": "pariatur qui laborum anim",
-            "value": "enim"
-        },
-        {
-            "source": "esse deserunt sed Excepteur",
-            "value": "nulla com"
+            "source": "velit ipsum laboris ut",
+            "value": "dolor consectetur cupidatat"
         }
     ],
     "acquisition_source": {
-        "datetime": "2234-06-08T05:46:05.263Z",
-        "email": "rLmoeWrC4fI6iZ@IBfNPyIlR.vwp",
-        "internal_uid": 76120453,
-        "method": "submitter",
-        "orcid": "8351-4483-7418-2367",
-        "source": "voluptate qui fugiat nulla",
-        "submission_number": "voluptate reprehenderit nisi nostrud elit"
+        "datetime": "4304-11-26T19:06:42.174Z",
+        "email": "pVVrEe@MmlIcjKPLxBtExOp.qdw",
+        "internal_uid": 72687687,
+        "method": "oai",
+        "orcid": "1903-3107-9467-2138",
+        "source": "occaecat",
+        "submission_number": "dolore magna voluptate"
     },
     "advisors": [
         {
-            "curated_relation": false,
-            "degree_type": "other",
+            "curated_relation": true,
+            "degree_type": "master",
             "ids": [
                 {
-                    "schema": "INSPIRE ID",
-                    "value": "INSPIRE-05641039"
+                    "schema": "SCOPUS",
+                    "value": "18855076548"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "5507083463"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "3429582774"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "63110116154"
                 }
             ],
-            "name": "dolor consequat ad reprehenderit",
+            "name": "deserunt labore est",
             "record": {
-                "$ref": "http://1]mQ"
+                "$ref": "http://1"
+            }
+        },
+        {
+            "curated_relation": true,
+            "degree_type": "diploma",
+            "ids": [
+                {
+                    "schema": "SCOPUS",
+                    "value": "7258926289"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "9550301108"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "38431775895"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "2009838052"
+                }
+            ],
+            "name": "incididunt eu est",
+            "record": {
+                "$ref": "http://1"
+            }
+        },
+        {
+            "curated_relation": false,
+            "degree_type": "diploma",
+            "ids": [
+                {
+                    "schema": "SCOPUS",
+                    "value": "9804295987"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "06490984394"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "69227801133"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "82201644403"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "0622828346"
+                }
+            ],
+            "name": "ea voluptate esse commodo",
+            "record": {
+                "$ref": "http://1X!1}>p\""
+            }
+        },
+        {
+            "curated_relation": false,
+            "degree_type": "diploma",
+            "ids": [
+                {
+                    "schema": "SCOPUS",
+                    "value": "5266321544"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "09091874507"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "2090387106"
+                }
+            ],
+            "name": "minim",
+            "record": {
+                "$ref": "http://1.e2T.9)>"
             }
         }
     ],
     "arxiv_categories": [
-        "q-fin.TR",
-        "math.RT"
+        "physics.ed-ph",
+        "cs.SD",
+        "math.AG",
+        "q-bio.GN"
     ],
-    "birth_date": "dddd-dd-dd",
+    "birth_date": "1991-10-21",
     "conferences": [
         {
-            "$ref": "http://1b`:5W0"
+            "$ref": "http://1]| cswr%"
         },
         {
-            "$ref": "http://1cW)$::^2L5"
+            "$ref": "http://1iS3Rnw"
         },
         {
-            "$ref": "http://1"
+            "$ref": "http://1F%|'$!;Q{"
         },
         {
-            "$ref": "http://1T'"
-        },
-        {
-            "$ref": "http://1H"
+            "$ref": "http://1jpRGM^a"
         }
     ],
-    "control_number": -88658604,
-    "death_date": "dddd-dd-dd",
+    "control_number": 51954716,
+    "death_date": "2014-10-10",
     "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://10,cz%J"
+            "$ref": "http://1qI7O!"
         },
         {
-            "$ref": "http://1.H"
+            "$ref": "http://1Dh"
+        },
+        {
+            "$ref": "http://1w7a<p"
+        },
+        {
+            "$ref": "http://1m4iwA7GCY|"
+        },
+        {
+            "$ref": "http://12mRGx6"
         }
     ],
     "email_addresses": [
-        "jGN@UgIuoDPV.zeyf"
+        "QTFJPFxI@gpZDzOP.yg",
+        "TlBv9BJN0NLqCzI@qmBPBjhkDMLlDUqCjdbLBzJg.kyo",
+        "G8X2k9IuM4qGjB@LYHLZMcF.awj"
     ],
     "experiments": [
         {
+            "curated_relation": true,
+            "current": true,
+            "end_year": -19766966,
+            "name": "amet dolore in voluptate",
+            "record": {
+                "$ref": "http://1;zWS[a"
+            },
+            "start_year": -4478687
+        },
+        {
             "curated_relation": false,
             "current": false,
-            "end_year": 84089160,
+            "end_year": -42706407,
             "name": "anim",
             "record": {
-                "$ref": "http://1l"
+                "$ref": "http://1Ql!C"
             },
-            "start_year": 76070958
+            "start_year": 65829453
+        },
+        {
+            "curated_relation": false,
+            "current": false,
+            "end_year": -12950221,
+            "name": "in culpa reprehenderit",
+            "record": {
+                "$ref": "http://1/G"
+            },
+            "start_year": 51465543
         },
         {
             "curated_relation": true,
-            "current": false,
-            "end_year": 25013000,
-            "name": "deserunt qui laboris velit c",
+            "current": true,
+            "end_year": 14413622,
+            "name": "ut ut nostrud laborum",
             "record": {
-                "$ref": "http://16}skmAF["
+                "$ref": "http://1t"
             },
-            "start_year": 47096382
+            "start_year": 11916566
+        },
+        {
+            "curated_relation": true,
+            "current": true,
+            "end_year": 39168632,
+            "name": "sed et id sit",
+            "record": {
+                "$ref": "http://1>=6r>I"
+            },
+            "start_year": 24393456
         }
     ],
     "ids": [
         {
-            "schema": "GOOGLESCHOLAR",
-            "value": "O0B---S--m-Y"
+            "schema": "CERN",
+            "value": "CERN-95979"
         },
         {
-            "schema": "GOOGLESCHOLAR",
-            "value": "-t-fRAa---ZA"
+            "schema": "CERN",
+            "value": "CERN-75270"
         },
         {
-            "schema": "GOOGLESCHOLAR",
-            "value": "i-3u-I--GGjc"
+            "schema": "CERN",
+            "value": "CERN-2"
         },
         {
-            "schema": "GOOGLESCHOLAR",
-            "value": "YK-EM---u--r"
-        },
-        {
-            "schema": "GOOGLESCHOLAR",
-            "value": "-aIE_--ljv41"
+            "schema": "CERN",
+            "value": "CERN-75"
         }
     ],
     "inspire_categories": [
         {
-            "source": "undefined",
-            "term": "Theory-Nucl"
+            "source": "magpie",
+            "term": "Lattice"
+        },
+        {
+            "source": "user",
+            "term": "Math and Math Physics"
         },
         {
             "source": "curator",
+            "term": "Experiment-Nucl"
+        },
+        {
+            "source": "user",
             "term": "Gravitation and Cosmology"
         },
         {
-            "source": "arxiv",
-            "term": "Gravitation and Cosmology"
+            "source": "magpie",
+            "term": "General Physics"
         }
     ],
-    "legacy_creation_date": "2645-01-15T22:38:52.352Z",
+    "legacy_creation_date": "1995-04-29",
     "name": {
-        "numeration": "I",
-        "preferred_name": "reprehenderit sunt",
+        "numeration": "VIII",
+        "preferred_name": "ut",
         "title": "",
-        "value": "n, %Wq~IV"
+        "value": "\\!ZpSPj, @Xq}U~,%Hj"
     },
     "native_name": [
-        "officia"
+        "et eu irure aliquip ut",
+        "ex in velit dolor Lorem",
+        "commodo sint non",
+        "reprehend",
+        "Duis voluptate eu"
     ],
     "new_record": {
-        "$ref": "http://1|"
+        "$ref": "http://1/^}vZW'"
     },
     "other_names": [
-        "minim",
-        "culpa non fugiat est anim",
-        "aliqua dolor ",
-        "sit enim fugiat aliquip"
+        "ut adipisicing quis proident",
+        "Lorem laboris labore"
     ],
     "past_emails_addresses": [
-        "0Qq9b@sTgmOFOkzcpjjHcZOa.lzz",
-        "aTAOPZtCJDnXJZ@oAgdBErcxfqUGCJqXuQXtsqQxFViUk.vnch"
+        "HB5p4Y@dk.luz"
     ],
     "positions": [
         {
-            "_rank": "eu sint",
+            "_rank": "in quis dolor",
             "current": false,
             "emails": [
-                "iHBj@wjhYBpCV.xe",
-                "WUO2DOF-9Mf4Dd3@MnQjrupFxeaCpNEtnEZNNIh.pvdx"
+                "IZt@sphebuxfTLTHna.ebkw",
+                "oG-Y@utSFsyDGStC.hnqs"
             ],
-            "end_date": "dddd-dd-dd",
-            "institution": {
-                "curated_relation": true,
-                "name": "adipisicing magna ad id nisi",
-                "record": {
-                    "$ref": "http://1ypheB"
-                }
-            },
-            "old_emails": [
-                "KGjKSGESBEWolK@KYnEEzQXhwEz.xdh",
-                "aF2FpwpP8Z@QeXMMTx.pkp",
-                "nA0h9kyQP0M3@vHtelmKfipmMhAcEgTb.daip"
-            ],
-            "rank": "POSTDOC",
-            "start_date": "dddd-dd-dd"
-        },
-        {
-            "_rank": "dolor voluptate dolo",
-            "current": false,
-            "emails": [
-                "EoBmF6U@wtUmCyDkiszvEUyqfaObdKCt.hbxe",
-                "rTCHoPknOz1Is@hHxKrtZjjhfdWLfzjQbGiLLoeJuFIcT.qpj"
-            ],
-            "end_date": "dddd-dd-dd",
+            "end_date": "1985-11-19",
             "institution": {
                 "curated_relation": false,
-                "name": "anim ipsum",
+                "name": "quis",
                 "record": {
-                    "$ref": "http://1&Z"
+                    "$ref": "http://1p>w|)"
                 }
             },
             "old_emails": [
-                "H3MNTiS@cOAeoJUgCuSDQHqFpVRiKfomfpB.peso",
-                "lc6b@fUaiJyZNciCUBwAeI.xsp"
+                "FE1Dm8Ro6quX@FNIZBbK.ssv"
             ],
-            "rank": "UNDERGRADUATE",
-            "start_date": "dddd-dd-dd"
-        },
-        {
-            "_rank": "Duis",
-            "current": true,
-            "emails": [
-                "0a7@WaeBRiKoESegQzMDZucSqUbri.gpk",
-                "EB2QX1lviO@dDQztxxjPwYlHlwcVT.tl"
-            ],
-            "end_date": "dddd-dd-dd",
-            "institution": {
-                "curated_relation": false,
-                "name": "in Duis",
-                "record": {
-                    "$ref": "http://1IYO4pp7,i4"
-                }
-            },
-            "old_emails": [
-                "uXJZUllUa06@OfXLVSqjtzGemWnUdNOh.ttu",
-                "0nUivvavYn4be@yuVPZQ.ie"
-            ],
-            "rank": "JUNIOR",
-            "start_date": "dddd-dd-dd"
+            "rank": "STAFF",
+            "start_date": "1989-09-01"
         }
     ],
     "previous_names": [
-        "ad Ut ipsum veniam mollit",
-        "sed",
-        "Lorem",
-        "et",
-        "nulla velit incid"
+        "deserunt aute commodo eiusmod",
+        "ad deserunt cupi",
+        "dolore magna ad sit deserunt",
+        "ex fugiat est"
     ],
     "prizes": [
-        "commodo quis laborum",
-        "sunt",
-        "pariatur",
-        "non Lorem",
-        "labore mollit Excepteur Duis"
+        "ut mollit",
+        "esse nulla ut",
+        "sed",
+        "consectetur ipsum",
+        "dolor ad irure"
     ],
     "public_notes": [
         {
-            "source": "incididunt deserunt",
-            "value": "dolore mollit"
+            "source": "mollit sed proident veniam deserunt",
+            "value": "Duis dolor do exercitation adipisicing"
         },
         {
-            "source": "Lorem consequat dolore",
-            "value": "non Excepteur"
+            "source": "voluptate nulla",
+            "value": "Ut eiusmod eu"
+        },
+        {
+            "source": "fugiat sit in tempor ad",
+            "value": "officia nostrud sunt fugiat"
         }
     ],
     "self": {
-        "$ref": "http://1=/"
+        "$ref": "http://1~\""
     },
     "source": [
         {
-            "date_verified": "dddd-dd-dd",
-            "name": "non velit est sed laboris"
+            "date_verified": "1988-09-13",
+            "name": "Ut ut sint non"
         },
         {
-            "date_verified": "dddd-dd-dd",
-            "name": "et"
+            "date_verified": "1977-09-11",
+            "name": "occaecat consectetur"
+        },
+        {
+            "date_verified": "1991-07-22",
+            "name": "et nisi aliqua eiusmod dolor"
         }
     ],
-    "status": "deceased",
+    "status": "departed",
     "stub": true,
     "urls": [
         {
-            "description": "cupidatat occaecat aliqua",
-            "value": "http://1"
+            "description": "et ipsum",
+            "value": "http://1("
+        },
+        {
+            "description": "id s",
+            "value": "http://1C<"
+        },
+        {
+            "description": "commodo non ",
+            "value": "http://17c>x@;zb["
+        },
+        {
+            "description": "adipisicing labore ipsum commodo Duis",
+            "value": "http://1~,w?"
         }
     ]
 }

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -4,221 +4,224 @@
     ],
     "_private_notes": [
         {
-            "source": "consectetur eiusmod aliqua sit quis",
-            "value": "enim dolore et"
+            "source": "est amet culpa tempor",
+            "value": "Ut quis ut pariatur"
+        },
+        {
+            "source": "commo",
+            "value": "cillum ullamco aliquip sint eiusmod"
+        },
+        {
+            "source": "magna deserunt exercitation au",
+            "value": "esse"
+        },
+        {
+            "source": "amet in do officia",
+            "value": "ipsum"
         }
     ],
     "acronyms": [
-        "Duis",
-        "veniam",
-        "ex",
-        "Lorem aliqua sed elit labor",
-        "reprehenderit ipsum elit sed do"
+        "ut"
     ],
     "address": [
         {
             "cities": [
-                "exercitation dolor",
-                "nisi"
+                "aliqua Duis adipisicing",
+                "quis labore amet",
+                "sed est consectetur do",
+                "sed sint ut"
             ],
-            "country_code": "KI",
-            "latitude": 25225485,
-            "longitude": 47606447,
-            "place_name": "amet minim ex",
+            "country_code": "HN",
+            "latitude": 98176984,
+            "longitude": -89125791,
+            "place_name": "qui anim",
             "postal_address": [
-                "reprehenderit",
-                "eu in qui"
+                "qui",
+                "anim voluptate",
+                "voluptate incididunt sunt",
+                "laboris aute ullamco",
+                "aute dolor qui nostrud culpa"
             ],
-            "postal_code": "culpa",
-            "state": "commodo ex incididunt pariatur Excepteur"
-        },
-        {
-            "cities": [
-                "minim voluptate ipsum est ",
-                "cupidatat Duis aute",
-                "in et enim"
-            ],
-            "country_code": "JE",
-            "latitude": 33216539,
-            "longitude": 55052667,
-            "place_name": "proident pariatur fugiat aliquip",
-            "postal_address": [
-                "minim exercitation",
-                "consectetur fugiat aliquip ",
-                "fugiat in labore voluptate",
-                "pariatur est"
-            ],
-            "postal_code": "anim",
-            "state": "nostrud"
-        },
-        {
-            "cities": [
-                "cillum aliqua magna ut",
-                "laboris consequat qui velit sunt",
-                "elit Excepteur laboris"
-            ],
-            "country_code": "TG",
-            "latitude": -91593122,
-            "longitude": 56814578,
-            "place_name": "laborum occaecat ",
-            "postal_address": [
-                "Ut amet anim aute ir",
-                "aliqua"
-            ],
-            "postal_code": "culpa ut",
-            "state": "aliquip minim tempor laborum"
-        },
-        {
-            "cities": [
-                "ullamco reprehenderit sed Ut",
-                "culpa l"
-            ],
-            "country_code": "NP",
-            "latitude": 28145551,
-            "longitude": 9708120,
-            "place_name": "ad sunt ipsum",
-            "postal_address": [
-                "adi",
-                "qui cillum aliquip",
-                "dolore sit",
-                "ipsum labore qui enim",
-                "culpa dolore tempor"
-            ],
-            "postal_code": "adipisicing cillum in nisi qui",
-            "state": "consectetur labore"
+            "postal_code": "officia eiusmod incididunt veniam Lorem",
+            "state": "adipisicing ullamco velit"
         }
     ],
     "alternative_titles": [
         {
-            "source": "Lorem esse est",
-            "subtitle": "nulla",
-            "title": "ex et amet"
+            "source": "velit laboris labore",
+            "subtitle": "velit voluptate Excepteur",
+            "title": "occaecat exercitation proident do ullamco"
         },
         {
-            "source": "voluptate dolor tempor nulla Lorem",
-            "subtitle": "aute ea",
-            "title": "culpa nisi enim consequat"
+            "source": "deserunt irure ipsum elit eiusmod",
+            "subtitle": "aute amet eiusmod",
+            "title": "enim"
+        },
+        {
+            "source": "sed",
+            "subtitle": "nulla do anim",
+            "title": "reprehenderit in"
         }
     ],
-    "closing_date": "9970-53-12",
-    "cnum": "C22-27-79",
+    "closing_date": "1992-12-16",
+    "cnum": "C94-08-83.91",
     "contact_details": [
         {
-            "email": "bKWv2swvHCR3@QwpSSpLi.ogq",
-            "name": "nostrud"
+            "email": "bZxp3Hsm7Pso@Fka.gtn",
+            "name": "ad"
         },
         {
-            "email": "TLLRs8dIm7@nErajlyWRmUD.fr",
-            "name": "velit ex in"
+            "email": "h6W-lnw6jsexx8@DeuIWrRWAd.kta",
+            "name": "nostrud veniam occaecat"
         },
         {
-            "email": "MpQnpH10tl@FxNtKLeZlENwBfNRYlFRdcFAg.drw",
-            "name": "aliquip proident quis nisi id"
+            "email": "WtQ8kumrC@JXptKrUpfhwbbBwqpNtFyfYS.dv",
+            "name": "reprehenderit nisi ea"
         },
         {
-            "email": "FGwVJjsKxw@egtGIsArRoFDzhNIaWACguFqzBEpZARS.gy",
-            "name": "deserunt enim veniam ut"
+            "email": "HjsM@oeAIcOTExJFyFewmDhVQSkreImSb.nyet",
+            "name": "eu"
         }
     ],
-    "control_number": -50837128,
+    "control_number": -34417471,
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1|6%M"
+            "$ref": "http://1"
+        },
+        {
+            "$ref": "http://1,~DqZ?"
+        },
+        {
+            "$ref": "http://1:Q"
+        },
+        {
+            "$ref": "http://1Uo%/k"
         }
     ],
     "external_system_identifiers": [
         {
             "schema": "SPIRES",
-            "value": "CONF-971113"
+            "value": "CONF-572534739"
+        },
+        {
+            "schema": "SPIRES",
+            "value": "CONF-836498"
+        },
+        {
+            "schema": "SPIRES",
+            "value": "CONF-0015697"
+        },
+        {
+            "schema": "SPIRES",
+            "value": "CONF-476392"
         }
     ],
     "inspire_categories": [
         {
-            "source": "magpie",
-            "term": "Math and Math Physics"
+            "source": "user",
+            "term": "Gravitation and Cosmology"
+        },
+        {
+            "source": "user",
+            "term": "General Physics"
         },
         {
             "source": "curator",
-            "term": "Other"
+            "term": "Math and Math Physics"
         },
         {
-            "source": "magpie",
-            "term": "Gravitation and Cosmology"
+            "source": "undefined",
+            "term": "Astrophysics"
         }
     ],
-    "legacy_creation_date": "4249-07-07T16:32:56.171Z",
+    "legacy_creation_date": "2019-05-28",
     "new_record": {
-        "$ref": "http://1E.F"
+        "$ref": "http://1Srx"
     },
-    "opening_date": "9440-93-68",
+    "opening_date": "1974-09-14",
     "public_notes": [
         {
-            "source": "ut exercitation sit",
-            "value": "in non anim"
+            "source": "",
+            "value": "sed Lorem culpa elit proident"
         },
         {
-            "source": "aute est",
-            "value": "sed officia irure nisi"
+            "source": "anim eu cupidat",
+            "value": "consectetur Excepteur aute"
         },
         {
-            "source": "sunt voluptate dolor sed am",
-            "value": "est aliqua ex irure"
+            "source": "veniam",
+            "value": "laborum commodo"
         },
         {
-            "source": "veniam consequat",
-            "value": "in enim dolor quis nostr"
+            "source": "deserunt Excepteur et",
+            "value": "Excepteur exercitation"
         }
     ],
     "self": {
-        "$ref": "http://1K-@.C:.>"
+        "$ref": "http://1=WXIwz*5"
     },
     "series": [
         {
-            "name": "laboris dolor esse ex sunt",
-            "number": -36121897
+            "name": "proident sed tempor sunt",
+            "number": 58685761
         },
         {
-            "name": "ex sunt ipsum",
-            "number": -43434899
-        },
-        {
-            "name": "",
-            "number": 23072861
-        },
-        {
-            "name": "id exercitation nulla reprehenderit in",
-            "number": 60862216
+            "name": "Excepteur aliquip reprehenderit cupidatat officia",
+            "number": 71519468
         }
     ],
     "short_description": {
-        "source": "occaecat cupidatat consequat",
-        "value": "voluptate"
+        "source": "ut mollit in",
+        "value": "ex in"
     },
     "titles": [
         {
-            "source": "ut",
-            "subtitle": "Ut pariatur ipsum",
-            "title": "esse dolor cillum officia in"
+            "source": "anim proident ipsum Excepteur amet",
+            "subtitle": "velit",
+            "title": "est ullamco ut dolor mollit"
         },
         {
-            "source": "dolor sed elit enim",
-            "subtitle": "pariatur laborum",
-            "title": "aliqua aliquip est"
+            "source": "sed",
+            "subtitle": "qui",
+            "title": "magna Ut"
+        },
+        {
+            "source": "ipsum in",
+            "subtitle": "adipisicing ad",
+            "title": "in"
+        },
+        {
+            "source": "consequat nisi occaecat",
+            "subtitle": "in mollit sint id",
+            "title": "in nostrud Lorem ut dolore"
+        },
+        {
+            "source": "consequat",
+            "subtitle": "do",
+            "title": "conse"
         }
     ],
     "urls": [
         {
-            "description": "amet aliqua ad",
-            "value": "http://1D"
+            "description": "Lorem minim",
+            "value": "http://1c"
         },
         {
-            "description": "deserunt ",
-            "value": "http://1Fm8"
+            "description": "ut incididunt sit deserunt dolor",
+            "value": "http://1'"
         },
         {
-            "description": "dolore elit pariatur enim",
-            "value": "http://1Z*G*u*1n(V"
+            "description": "fugiat minim dolor Duis",
+            "value": "http://1IAaWsk="
+        },
+        {
+            "description": "sint occaecat proident id adipisicing",
+            "value": "http://1^p-~Bi0"
+        },
+        {
+            "description": "sit elit labore",
+            "value": "http://1S&UAB"
         }
     ]
 }

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -2,203 +2,172 @@
     "_collections": [
         "Experiments"
     ],
-    "_full_ingestion": false,
+    "_full_ingestion": true,
     "_private_notes": [
         {
-            "source": "velit proident id officia anim",
-            "value": "in magna"
+            "source": "fugiat",
+            "value": "ipsum"
         },
         {
-            "source": "sed",
-            "value": "fugiat"
+            "source": "fugiat tempor culpa anim",
+            "value": "minim Ut ea cupidatat"
         },
         {
-            "source": "do",
-            "value": "laborum aliquip labore tempor et"
-        },
-        {
-            "source": "exercitation ut id",
-            "value": "dolore reprehenderit laboris Duis"
-        },
-        {
-            "source": "exercitation cupidatat elit",
-            "value": "adipisicing"
+            "source": "ullamco Excepteur ea culpa aliqua",
+            "value": "fugiat sed culpa"
         }
     ],
     "accelerator": {
         "curated_relation": true,
         "record": {
-            "$ref": "http://1%w#6QS7 3"
+            "$ref": "http://1PK7LC\\,L6$"
         },
-        "value": "in laboris ut"
+        "value": "occaecat enim veniam incididunt fugiat"
     },
     "collaboration": {
-        "curated_relation": true,
+        "curated_relation": false,
         "record": {
-            "$ref": "http://1M)H-j"
+            "$ref": "http://1h=fzx^="
         },
         "subgroup_names": [
-            "qui",
-            "ullamco",
-            "aute occaecat cillum",
-            "magna voluptate"
+            "mollit Lorem quis",
+            "consequat anim occaecat",
+            "aliqua"
         ],
-        "value": "ali"
+        "value": "aliquip exercitation dolore off"
     },
-    "control_number": 67168215,
+    "control_number": 92638116,
     "core": true,
-    "date_approved": "9433-07-69",
-    "date_cancelled": "0653-71-44",
-    "date_completed": "5802-68-29",
-    "date_proposed": "3219-34-99",
-    "date_started": "2353-10-64",
-    "deleted": false,
+    "date_approved": "2002-06-14",
+    "date_cancelled": "2017-02-28",
+    "date_completed": "1996-07-19",
+    "date_proposed": "1994-11-26",
+    "date_started": "2014-03-21",
+    "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://1cWuNi0SHv"
+            "$ref": "http://1Ou$(?Pqa1/"
         },
         {
-            "$ref": "http://15;YDnm@0V"
+            "$ref": "http://1Vf'fg"
         }
     ],
-    "description": "ex officia nostrud irure",
+    "description": "consequat dolore in quis",
     "experiment": {
-        "short_name": "dolore enim et fugiat sed",
-        "value": "eiusmod nisi consectetur"
+        "short_name": "ea",
+        "value": "in labore"
     },
     "external_system_identifiers": [
         {
             "schema": "SPIRES",
-            "value": "EXPERIMENT-06"
+            "value": "EXPERIMENT-2820"
         },
         {
             "schema": "SPIRES",
-            "value": "EXPERIMENT-00"
-        },
-        {
-            "schema": "SPIRES",
-            "value": "EXPERIMENT-3583731183"
-        },
-        {
-            "schema": "SPIRES",
-            "value": "EXPERIMENT-66607"
+            "value": "EXPERIMENT-4"
         }
     ],
     "inspire_categories": [
-        {
-            "source": "arxiv",
-            "term": "Gravitation and Cosmology"
-        },
-        {
-            "source": "user",
-            "term": "Gravitation and Cosmology"
-        },
         {
             "source": "undefined",
             "term": "Gravitation and Cosmology"
         },
         {
-            "source": "curator",
-            "term": "Astrophysics"
+            "source": "undefined",
+            "term": "General Physics"
         },
         {
-            "source": "arxiv",
-            "term": "Math and Math Physics"
+            "source": "magpie",
+            "term": "Gravitation and Cosmology"
         }
     ],
     "inspire_classification": [
-        "2524636.01699231230",
-        "75605498072.9557776807",
-        "2189918480"
+        "2539892",
+        "58.855954",
+        "449.242",
+        "11738898792.8.702",
+        "0882010081"
     ],
     "institutions": [
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1qY XaZ@5Y"
+                "$ref": "http://1.K_ #-/"
             },
-            "value": "Duis enim eu"
+            "value": ""
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1"
+            },
+            "value": "ut"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1{VG-Aj@Yv"
+            },
+            "value": "laboris in"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1r"
+            },
+            "value": "proident"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1\\"
+            },
+            "value": "dolore"
         }
     ],
-    "legacy_creation_date": "3224-06-22T02:25:18.800Z",
-    "legacy_name": "laboris",
-    "long_name": "qui esse",
+    "legacy_creation_date": "1975-10-27",
+    "legacy_name": "aute officia anim aliqua consectetur",
+    "long_name": "laboris irure minim quis ex",
     "name_variants": [
-        "et minim",
-        "sunt sit mollit",
-        "tempor",
-        "nulla id",
-        "dolor minim"
+        "elit ipsum",
+        "ullamco dolor dolor esse",
+        "non "
     ],
     "new_record": {
-        "$ref": "http://1pr\">"
+        "$ref": "http://1sCTg"
     },
     "project_type": [
-        "experiment",
+        "accelerator",
         "collaboration",
-        "accelerator"
+        "experiment"
     ],
     "public_notes": [
         {
-            "source": "ad",
-            "value": "dolor esse anim"
+            "source": "ea irure",
+            "value": "Excepteur consequat"
         }
     ],
     "related_records": [
         {
+            "curated_relation": true,
             "record": {
-                "$ref": "http://1WBK$iU"
+                "$ref": "http://1E=y}"
             },
-            "relation": "parent"
-        },
-        {
-            "record": {
-                "$ref": "http://1O*"
-            },
-            "relation_freetext": "sint in"
-        },
-        {
-            "record": {
-                "$ref": "http://1#[^DQr1Nm"
-            },
-            "relation": "parent"
-        },
-        {
-            "record": {
-                "$ref": "http://1^d7I`c6HOG"
-            },
-            "relation_freetext": "aliquip cillum exercitation"
-        },
-        {
-            "record": {
-                "$ref": "http://1"
-            },
-            "relation": "predecessor"
+            "relation": "commented",
+            "relation_freetext": "mollit"
         }
     ],
     "self": {
-        "$ref": "http://1~OZ"
+        "$ref": "http://1rk1AKe[& m"
     },
     "urls": [
         {
-            "description": "cupidatat c",
-            "value": "http://1"
+            "description": "ut nisi",
+            "value": "http://1/M|"
         },
         {
             "description": "deserunt",
-            "value": "http://1|@)9Yl"
-        },
-        {
-            "description": "consectetur non Ut",
-            "value": "http://1Tj"
-        },
-        {
-            "description": "veniam",
-            "value": "http://1~)6!wrA=e<"
-        },
-        {
-            "description": "eu in dolore",
-            "value": "http://1,.}yv"
+            "value": "http://1ybsM8alB[:"
         }
     ]
 }

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1,131 +1,190 @@
 {
     "_collections": [
-        "D0 Internal Notes",
-        "HERMES Internal Notes",
-        "BABAR Analysis Documents",
-        "BABAR Internal BAIS"
+        "CDF Notes",
+        "ZEUS Internal Notes",
+        "HEP Hidden"
     ],
     "_desy_bookkeeping": [
         {
-            "date": "officia laboris",
-            "expert": "eu in",
-            "status": "fugiat"
+            "date": "deserunt laboris ad",
+            "expert": "labore id Duis",
+            "status": "anim"
         },
         {
-            "date": "ex pariatur sint fugiat",
-            "expert": "amet",
-            "status": "dolore ut"
+            "date": "nulla fugiat D",
+            "expert": "ex ea",
+            "status": "nulla dolore nostrud"
+        },
+        {
+            "date": "sed et quis aliqua deserunt",
+            "expert": "Duis proident",
+            "status": "esse magna veniam u"
+        },
+        {
+            "date": "pariatur dolor sunt ut occaecat",
+            "expert": "elit enim",
+            "status": "tempor dolore laboris"
+        },
+        {
+            "date": "magna exercitation est",
+            "expert": "exercitation id laboris labore",
+            "status": "fugiat enim consequat reprehenderit"
         }
     ],
     "_export_to": {
-        "CDS": true,
+        "CDS": false,
         "HAL": true
     },
     "_files": [
         {
-            "bucket": "Duis",
-            "checksum": "fugiat adipisicing ut",
-            "key": "ea est",
-            "size": -65093533,
-            "version_id": "veniam ad irure aliquip"
+            "bucket": "dolore et",
+            "checksum": "deserunt ut anim",
+            "key": "ut ullamco",
+            "size": -95482281,
+            "version_id": "ad irure anim aliqu"
         },
         {
-            "bucket": "aute",
-            "checksum": "do cupidatat Ut anim",
-            "key": "id anim sit et sed",
-            "size": 19307699,
-            "version_id": "qui"
+            "bucket": "sint non ",
+            "checksum": "reprehenderit dolor ad in",
+            "key": "ullamco ",
+            "size": -93453234,
+            "version_id": ""
         },
         {
-            "bucket": "Duis",
-            "checksum": "qui eu",
-            "key": "",
-            "size": 35073595,
-            "version_id": "adipisicing sit ut id"
+            "bucket": "esse deserunt",
+            "checksum": "do ut nisi eu",
+            "key": "adipisicing cupidatat ex in",
+            "size": -66367501,
+            "version_id": "Ut officia fugiat"
+        },
+        {
+            "bucket": "voluptate consequat id proident ex",
+            "checksum": "proident magna sed Excepteur",
+            "key": "pariatur sit qui do",
+            "size": -52266773,
+            "version_id": "laboris fugiat anim et"
+        },
+        {
+            "bucket": "culpa deserunt",
+            "checksum": "ullamco anim",
+            "key": "et",
+            "size": -53239456,
+            "version_id": "eu Excepteur voluptate elit cupidatat"
         }
     ],
     "_private_notes": [
         {
-            "source": "tempor",
-            "value": "fugiat consectetur anim"
+            "source": "amet Lorem Excepteur id",
+            "value": "exercitation ad"
         },
         {
-            "source": "nulla laborum sunt",
-            "value": "exercitation sit minim in laborum"
-        },
-        {
-            "source": "occaecat adip",
-            "value": "deserunt dolor"
+            "source": "in commodo officia laboris ullamco",
+            "value": "Ut incididunt qui enim"
         }
     ],
     "abstracts": [
         {
-            "source": "sed consequat",
-            "value": "sint"
+            "source": "aute commodo Ut ut esse",
+            "value": "ut laborum"
         },
         {
-            "source": "ea ex in exercitation",
-            "value": "exercitation elit laborum sit"
+            "source": "non pariatur",
+            "value": "officia sunt ea est"
+        },
+        {
+            "source": "adipisicing Duis eu Ut",
+            "value": "sed ea sunt cupidatat"
+        },
+        {
+            "source": "laboris tempor dolore",
+            "value": "laborum"
         }
     ],
     "accelerator_experiments": [
         {
-            "accelerator": "sit nostrud id paria",
+            "accelerator": "esse cupidatat pariatur",
             "curated_relation": true,
-            "experiment": "dolore pariatur Excepteur",
-            "institution": "minim deserunt",
-            "legacy_name": "laboris",
+            "experiment": "voluptate dolor cupidatat ullamco anim",
+            "institution": "culpa esse in",
+            "legacy_name": "aliquip sint nisi",
             "record": {
-                "$ref": "http://1_lh"
+                "$ref": "http://1+Q\\\\"
             }
         },
         {
-            "accelerator": "aliqua id",
+            "accelerator": "nostrud incididunt est aliqua aute",
+            "curated_relation": true,
+            "experiment": "quis in ea",
+            "institution": "nostrud enim esse",
+            "legacy_name": "laboris Ut",
+            "record": {
+                "$ref": "http://1}P9qA"
+            }
+        },
+        {
+            "accelerator": "sint",
+            "curated_relation": true,
+            "experiment": "amet consequat occaecat cupidatat",
+            "institution": "occaecat",
+            "legacy_name": "enim cupidatat",
+            "record": {
+                "$ref": "http://1B-EQu,c"
+            }
+        },
+        {
+            "accelerator": "non commodo ut mollit",
             "curated_relation": false,
-            "experiment": "dolor elit anim",
-            "institution": "qui nulla",
-            "legacy_name": "ame",
+            "experiment": "labo",
+            "institution": "sint proident",
+            "legacy_name": "ad",
             "record": {
-                "$ref": "http://14]d=)z+0"
+                "$ref": "http://10D"
             }
         },
         {
-            "accelerator": "dolor est sed",
+            "accelerator": "in tempor",
             "curated_relation": true,
-            "experiment": "adipisicing dolor dolor elit",
-            "institution": "ut dolore quis",
-            "legacy_name": "velit",
+            "experiment": "ex ut",
+            "institution": "Lorem sint",
+            "legacy_name": "ullamco laboris ex",
             "record": {
-                "$ref": "http://1zA"
+                "$ref": "http://1_!"
             }
         }
     ],
     "acquisition_source": {
-        "datetime": "4655-08-10T13:24:39.377Z",
-        "email": "YMD@FNozTaLqsdeiHRpHEe.gmlg",
-        "internal_uid": 33119180,
+        "datetime": "4990-12-11T20:44:51.890Z",
+        "email": "SugLj61Qwv@CybqNuIbifqwUNuDehEvYvNYRNNlHRrOf.oh",
+        "internal_uid": -18401376,
         "method": "submitter",
-        "orcid": "7517-2459-3361-8685",
-        "source": "do occaecat voluptate elit veniam",
-        "submission_number": "Lorem ad reprehenderit sed esse"
+        "orcid": "0856-9946-6161-3124",
+        "source": "in sed",
+        "submission_number": "aliquip anim dolor"
     },
     "arxiv_eprints": [
         {
             "categories": [
-                "math.DS",
-                "q-bio.PE",
-                "cs.DM"
+                "cs.OH",
+                "cs.HC",
+                "stat.OT"
             ],
-            "value": "1325s6032"
+            "value": "XjDOhs4Q-QehH/5441875"
         },
         {
             "categories": [
-                "q-bio.BM",
-                "q-fin.EC",
-                "cs.GT",
-                "math.GN"
+                "math.AC"
             ],
-            "value": "p/272"
+            "value": "olRIu_cR-9KZty2k4o9/04"
+        },
+        {
+            "categories": [
+                "q-bio.NC",
+                "cs.GT",
+                "physics.ins-det",
+                "physics.class-ph",
+                "cs.DC"
+            ],
+            "value": "0504o30732"
         }
     ],
     "authors": [
@@ -134,1154 +193,1001 @@
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1;@ly.\\"
+                        "$ref": "http://1h"
                     },
-                    "value": "in voluptate cupidatat do"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1OhTwI"
-                    },
-                    "value": "laboris nisi"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1x6vCW"
-                    },
-                    "value": "consectetur culpa ullamco"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1_$UXf"
-                    },
-                    "value": "dolor Lorem Ut eiusmod exercitation"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1$0yGA%"
-                    },
-                    "value": "quis mollit incididunt do"
+                    "value": "adipisicin"
                 }
             ],
             "alternative_names": [
-                "sint labore non in",
-                "voluptate fugiat irure",
-                "id Duis",
-                "exercitation",
-                "quis"
+                "qui do nisi proident deserunt",
+                "sint",
+                "adipisicing fugiat consequat aute",
+                "veniam commodo"
             ],
             "credit_roles": [
-                "Visualization",
+                "Conceptualization",
+                "Project administration",
+                "Project administration"
+            ],
+            "curated_relation": true,
+            "emails": [
+                "ciC@XVYuezNsxMQ.vxno",
+                "Y6IlZy7dWMq2Yn@aWZkX.oxit"
+            ],
+            "full_name": "Excepteur occaecat",
+            "ids": [
+                {
+                    "schema": "SCOPUS",
+                    "value": "03382559959"
+                }
+            ],
+            "inspire_roles": [
+                "supervisor",
+                "editor",
+                "supervisor",
+                "author"
+            ],
+            "raw_affiliations": [
+                {
+                    "source": "eiusmod",
+                    "value": "aliqua ut Excepteur amet Lorem"
+                },
+                {
+                    "source": "aliquip voluptate elit proident te",
+                    "value": "id ex velit"
+                },
+                {
+                    "source": "est sed deserunt enim",
+                    "value": "velit laborum"
+                },
+                {
+                    "source": "dolore",
+                    "value": "sunt"
+                },
+                {
+                    "source": "sunt aliqua ",
+                    "value": "cupidatat in"
+                }
+            ],
+            "record": {
+                "$ref": "http://1& ~D!R;h$."
+            },
+            "signature_block": "proident ut commodo irure nostrud",
+            "uuid": "5c2e01fd-6924-ce9f-10d3-0c44c07e55f4"
+        },
+        {
+            "affiliations": [
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1Jl"
+                    },
+                    "value": "velit"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1zU88K"
+                    },
+                    "value": "nisi sunt voluptate veniam proident"
+                }
+            ],
+            "alternative_names": [
+                "irure quis deserunt",
+                "laboris in",
+                "id occaecat dolore irure enim",
+                "mollit nulla"
+            ],
+            "credit_roles": [
                 "Project administration",
                 "Writing - original draft"
             ],
             "curated_relation": false,
             "emails": [
-                "Wjj43JvqvrqVTKy@ftqfOFCyixlsFVIrQqCwyOfj.eof"
+                "Pt4FEkxMKx@yPIrDksWtnogOhRHJgw.fts",
+                "3LQw6e1NBcqi@mzlZfWTHONGBIoJq.xe",
+                "kYh-FWez3Gw@dXsCMWrFviVMRHILCWAj.jquf",
+                "ZihbHj@CQbqcifkTSJxIhi.cyr",
+                "RR7HSyuraROZk-8@nbw.mfwf"
             ],
-            "full_name": "magna eu laboris",
+            "full_name": "ad Duis deserunt voluptate",
             "ids": [
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "--'--''2D.'-.-Z'5'.R'-p-8OF.2u--'q---Mc.-J4tX-'E--.7ES-''Q'UK-.'-'.--GV'.4'-6.49"
+                    "schema": "SCOPUS",
+                    "value": "43556937828"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "'---7Z-1.-v-''-'.'-'----.'.'Z'-'p.vN''N'.L5''-Ip'.'9--65.5"
+                    "schema": "SCOPUS",
+                    "value": "95739209436"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "-'.J'-'-c'-.'Al-'F.----.'-''w-''-Y-.1"
+                    "schema": "SCOPUS",
+                    "value": "79621683384"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "5c.ufp-vk''.-_w'_ymE'.Y-i-R--X'oA.-'8'''--uO.c''-'Q''-.'-N''''.'mLQ'Z-Qu''.912782116"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "''k.'''-''l.-'OJ-'.-i'ufl''-.0"
+                    "schema": "SCOPUS",
+                    "value": "74013562725"
                 }
             ],
             "inspire_roles": [
+                "editor",
+                "editor",
+                "author",
                 "supervisor",
-                "supervisor",
-                "author"
+                "supervisor"
             ],
             "raw_affiliations": [
                 {
-                    "source": "consectetur laboris",
-                    "value": "id et tempor amet"
+                    "source": "veniam nisi au",
+                    "value": "esse"
                 },
                 {
-                    "source": "dolore ipsum amet",
-                    "value": "dolore tempor consectetur adipisicing eu"
-                },
-                {
-                    "source": "fugiat et aliqu",
-                    "value": "in"
-                },
-                {
-                    "source": "ut elit fugiat",
-                    "value": "minim in amet exercitation officia"
-                },
-                {
-                    "source": "in",
-                    "value": "ut nulla exercitation ea"
+                    "source": "sunt cillum",
+                    "value": "volupt"
                 }
             ],
             "record": {
-                "$ref": "http://1j_~x,N"
+                "$ref": "http://130"
             },
-            "signature_block": "ut ullamco Duis sint",
-            "uuid": "4f4ec205-db6c-8b81-6ecc-25906813bd13"
+            "signature_block": "Lorem",
+            "uuid": "14bf6b45-00f9-a980-2a7f-5390ee0b721a"
         },
         {
             "affiliations": [
                 {
-                    "curated_relation": true,
+                    "curated_relation": false,
                     "record": {
-                        "$ref": "http://1"
+                        "$ref": "http://1\\:~B/)43F["
                     },
-                    "value": "amet adipisicing elit officia"
+                    "value": "ipsum elit"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1?MVG(cA3"
+                    },
+                    "value": "sunt sint nulla"
+                },
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1qwr8()BD>w"
+                    },
+                    "value": "in"
                 },
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1Lkw,P__8JI"
+                        "$ref": "http://17:0@PHP"
                     },
-                    "value": "aliqua est adipi"
+                    "value": "in fugiat ut"
                 }
             ],
             "alternative_names": [
-                "eu",
-                "fugiat dolore eiusmod ex",
-                "Ut"
+                "deserunt ex Ut",
+                "anim ipsum esse consectetur",
+                "dolor",
+                "magna qui in ipsum t"
             ],
             "credit_roles": [
-                "Validation",
-                "Funding acquisition"
+                "Project administration"
             ],
             "curated_relation": true,
             "emails": [
-                "16s6dBh0wBq@qgXaASXmEYFeHGPDYW.owap",
-                "dgtt@tffkscPOnfgHzx.moes",
-                "a9Lw@vXw.totw"
+                "5NaFqstfgILl@YwkZuB.eag",
+                "T6M5wv2oB@bcPIAehQmzUHDyDGntW.ovdo",
+                "bXPkOOp@bOCiSzTufIPejQncEL.hp"
             ],
-            "full_name": "",
+            "full_name": "nostrud ullamco non",
             "ids": [
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "'-'-E''k'c.074"
+                    "schema": "SCOPUS",
+                    "value": "43065059083"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "-y'-.-''e.--'5Kw'.'-cC'''A'rM.-S-''.U'.9"
+                    "schema": "SCOPUS",
+                    "value": "3901797027"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "2G-'5h.'-v.-'''I''.Kk''---''S.-1'Rz-N.b--'i'.'t-.25231190"
+                    "schema": "SCOPUS",
+                    "value": "3778239707"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "-q--w'----.-.-'-'.913508"
+                    "schema": "SCOPUS",
+                    "value": "26726972848"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "5-'O'-'-'.'-'jg.td.15"
+                    "schema": "SCOPUS",
+                    "value": "6709446450"
                 }
             ],
             "inspire_roles": [
-                "supervisor",
+                "editor"
+            ],
+            "raw_affiliations": [
+                {
+                    "source": "nostrud Excepteur",
+                    "value": "ad consequat"
+                },
+                {
+                    "source": "deserunt id",
+                    "value": "ut tempor Duis Excepteur"
+                },
+                {
+                    "source": "incididunt laborum nostrud",
+                    "value": "laboris exercitation deserunt cupidatat voluptate"
+                },
+                {
+                    "source": "eiusmod commodo reprehenderit",
+                    "value": "in"
+                }
+            ],
+            "record": {
+                "$ref": "http://1--J"
+            },
+            "signature_block": "adipisicing",
+            "uuid": "e093e62d-aaec-6ac7-5654-f9da71e163d1"
+        },
+        {
+            "affiliations": [
+                {
+                    "curated_relation": false,
+                    "record": {
+                        "$ref": "http://1m="
+                    },
+                    "value": "aute voluptate sed laboris"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1p`8L"
+                    },
+                    "value": "dolor in d"
+                },
+                {
+                    "curated_relation": true,
+                    "record": {
+                        "$ref": "http://1g7Zz[';k"
+                    },
+                    "value": "sit nulla aliquip labor"
+                }
+            ],
+            "alternative_names": [
+                "labore",
+                "anim laboris",
+                "aliquip amet"
+            ],
+            "credit_roles": [
+                "Project administration",
+                "Investigation",
+                "Conceptualization",
+                "Data curation",
+                "Writing - review & editing"
+            ],
+            "curated_relation": false,
+            "emails": [
+                "EXLKVKlJfXetVd@eZjmwEVvAIhPZEovjKVVhvhKUBhuORZ.ki"
+            ],
+            "full_name": "nisi aliquip non culpa",
+            "ids": [
+                {
+                    "schema": "SCOPUS",
+                    "value": "13663629228"
+                },
+                {
+                    "schema": "SCOPUS",
+                    "value": "36355606487"
+                }
+            ],
+            "inspire_roles": [
+                "author",
+                "author",
+                "author",
                 "author",
                 "author"
             ],
             "raw_affiliations": [
                 {
-                    "source": "consectetur magna sunt",
-                    "value": "Excep"
+                    "source": "ut quis magna eiusmod qui",
+                    "value": "in et ea culpa non"
                 },
                 {
-                    "source": "in sint nisi veniam eiusmod",
-                    "value": "Duis cupidatat ut"
-                },
-                {
-                    "source": "fugiat",
-                    "value": "consectetur"
+                    "source": "tempor ullamco in",
+                    "value": "est cillum"
                 }
             ],
             "record": {
-                "$ref": "http://12"
+                "$ref": "http://1v60L!2M6-O"
             },
-            "signature_block": "aute",
-            "uuid": "ea115ce2-c6fa-bd62-4391-0b3375cbc06e"
+            "signature_block": "est",
+            "uuid": "ae5afd4c-c5c2-df10-298a-6ea187577de8"
         },
         {
             "affiliations": [
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1"
+                        "$ref": "http://118^"
                     },
-                    "value": "sed commodo sunt irure minim"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1'1xvpCkx"
-                    },
-                    "value": "qui"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1;"
-                    },
-                    "value": "esse cillum deserunt Ut aliqua"
+                    "value": "proident eiusmod"
                 }
             ],
             "alternative_names": [
-                "proident exercitation",
-                "eu exercitation",
-                "aliquip enim amet",
-                "dolor Ut et"
+                "veniam dolor",
+                "irure adipisicing aliquip est dolore"
             ],
             "credit_roles": [
-                "Conceptualization",
-                "Methodology",
-                "Writing - review & editing",
+                "Visualization",
+                "Resources",
                 "Writing - original draft",
-                "Data curation"
+                "Investigation",
+                "Investigation"
             ],
             "curated_relation": true,
             "emails": [
-                "nYS94kvlPB7x@AmyDPOVdVZEGv.vrll",
-                "0vlvEbnnlnL@XweDlaNtwHSAmOeOdune.hnm",
-                "e0mbNH7@cJjhz.wpw"
+                "dE63i5@GowOFCJhEOxcLthZOFbIBAxTTTQEYDJc.shj",
+                "3c1zAHD16@hoQXkAUpjlthAktP.ms",
+                "J-CIYkALE7i@aEaeGcERktdYRCrGNwngRfxJhOhSUyIX.qrqq",
+                "D0GHXSmgsHj@LQCfUBWQChtxaNfgcKpjBn.cab",
+                "AUYEICRMXq@EvPziLLWNqtTYWPlSrKIFEA.lp"
             ],
-            "full_name": "nulla",
+            "full_name": "et esse",
             "ids": [
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "T--.'kaA---w'7-.'.-.277"
+                    "schema": "SCOPUS",
+                    "value": "5324071883"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "v-'5'.478246"
+                    "schema": "SCOPUS",
+                    "value": "96600396621"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "Q'Fg.A-''''-.-L'-n.i.'.-'3''G'y'-4.--v-'--.-A4''-.'ke''-b-'.l.09083492495"
+                    "schema": "SCOPUS",
+                    "value": "46797489699"
                 },
                 {
-                    "schema": "INSPIRE BAI",
-                    "value": "'.-.-A6'Hm-.'.'--.79677"
+                    "schema": "SCOPUS",
+                    "value": "3470874426"
                 }
             ],
             "inspire_roles": [
-                "supervisor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "ullamco",
-                    "value": "laboris occaecat"
-                },
-                {
-                    "source": "exercitation anim quis dolor",
-                    "value": "dolor cillum"
-                }
-            ],
-            "record": {
-                "$ref": "http://1]e.>"
-            },
-            "signature_block": "qui id cillum in ullamco",
-            "uuid": "958b43cd-296b-7e5e-035b-ea2ae43152be"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1~hHLr`"
-                    },
-                    "value": "Duis ut eiusmod dolore"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1'"
-                    },
-                    "value": "ipsum"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://15B,4d7C/"
-                    },
-                    "value": "consequat consectetur sunt"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1$zH"
-                    },
-                    "value": "ut dol"
-                },
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1Hpht"
-                    },
-                    "value": "Ut Excepteur in et"
-                }
-            ],
-            "alternative_names": [
-                "dolore elit",
-                "et consequat ad occae",
-                "id sit",
-                "et cupidatat cillum irure",
-                "sint dolor"
-            ],
-            "credit_roles": [
-                "Validation"
-            ],
-            "curated_relation": false,
-            "emails": [
-                "quwrdxQnxjI4@MrmolR.dm",
-                "ntYEfLYO@mTdqfMIxUHzYiaX.mk",
-                "xfI@pRkABpZZjgGUreYHjO.tm",
-                "qagLoVR0HxqCKsu@aazjBJPMKlMmZrcFeQBwqNTMs.ujk"
-            ],
-            "full_name": "cillum velit ipsum adipisicing ad",
-            "ids": [
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "S'C.''w.aL'pbd'--.517206607"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "'-Y'.'-nm.''--'7''xo'.s-'1.R----.'--.'P''b.'-.n-''x.46768"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "'G-'''.'FMF'--p.''s-'.'-'a''.'-'nk-Yir8'.'I'r5--c.cx.3USXXuk'-'.-l'2.-M-TEp.9345415"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "J'--D-.0'-icIS9'-.-.-'-'''.--c-Z'.--'---.SE'-e-'.-g'u'AV--.'.'-MEq-''4-.-.8246"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "Zol_.--u'e'---.--'ZE--.''s-'-'svDP.'.'i'8a.''z.435"
-                }
-            ],
-            "inspire_roles": [
-                "supervisor"
-            ],
-            "raw_affiliations": [
-                {
-                    "source": "Ut dolore dolor consequat",
-                    "value": "ullamco"
-                },
-                {
-                    "source": "",
-                    "value": "elit ea nisi dolore"
-                },
-                {
-                    "source": "nulla in",
-                    "value": "cupidatat veniam"
-                },
-                {
-                    "source": "dolore sed",
-                    "value": "sunt ut Excepteur velit ea"
-                }
-            ],
-            "record": {
-                "$ref": "http://1"
-            },
-            "signature_block": "mollit",
-            "uuid": "aaf32f78-8087-2054-54ac-e9b8d67be7e0"
-        },
-        {
-            "affiliations": [
-                {
-                    "curated_relation": false,
-                    "record": {
-                        "$ref": "http://1syM"
-                    },
-                    "value": "aliqua ad nostrud Lorem"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1x/@5}j"
-                    },
-                    "value": "qui"
-                },
-                {
-                    "curated_relation": true,
-                    "record": {
-                        "$ref": "http://1%"
-                    },
-                    "value": "amet exercitation enim"
-                }
-            ],
-            "alternative_names": [
-                "sit Excepteur veniam dolore",
-                "ullamco nulla eiusmod"
-            ],
-            "credit_roles": [
-                "Validation",
-                "Writing - original draft",
-                "Methodology"
-            ],
-            "curated_relation": false,
-            "emails": [
-                "HywsjBepaDolVN@pnfXTYELzvLgno.iwo",
-                "x4GKouPxZdyOQ@hUcTrYJOGQ.xx"
-            ],
-            "full_name": "Excep",
-            "ids": [
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "'.G'B-.'r'.5.-'av--._f-e''''.70646"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "'L-.p0x-''.370"
-                },
-                {
-                    "schema": "INSPIRE BAI",
-                    "value": "i''.H'.-.r''q'-'--.''---k-'.-'.-'''-''.'W.''C8'q-'--4.4808350"
-                }
-            ],
-            "inspire_roles": [
+                "author",
+                "author",
+                "editor",
                 "author",
                 "editor"
             ],
             "raw_affiliations": [
                 {
-                    "source": "ea sit anim",
-                    "value": "mollit"
-                },
-                {
-                    "source": "reprehenderit ut cillum",
-                    "value": "irure"
-                },
-                {
-                    "source": "irure",
-                    "value": "Lorem commodo adipisicing dolore"
-                },
-                {
-                    "source": "deserunt dolore nulla",
-                    "value": "ex"
+                    "source": "consequat exercitation veniam dolor",
+                    "value": "Excepteur dolor commod"
                 }
             ],
             "record": {
-                "$ref": "http://1_>{0>@D"
+                "$ref": "http://1:q#ov?/"
             },
-            "signature_block": "nisi Lorem eu non",
-            "uuid": "8e3c0367-3f64-f30b-c246-e30b401b94ce"
+            "signature_block": "do temp",
+            "uuid": "adfd51c0-e7da-9016-9919-b9843ab279e3"
         }
     ],
     "book_series": [
         {
-            "title": "voluptate ut",
-            "volume": "dol"
+            "title": "ipsum",
+            "volume": "in ut"
         },
         {
-            "title": "enim in labore culpa",
-            "volume": "amet quis dolore sed sit"
-        },
-        {
-            "title": "ea",
-            "volume": "reprehenderit veniam"
-        },
-        {
-            "title": "occaecat",
-            "volume": "fugi"
+            "title": "non laboris",
+            "volume": "vo"
         }
     ],
-    "citeable": true,
+    "citeable": false,
     "collaborations": [
         {
             "record": {
-                "$ref": "http://1nIN"
+                "$ref": "http://1o,"
             },
-            "value": "proident minim eu sun"
+            "value": "cupidatat"
         },
         {
             "record": {
-                "$ref": "http://17s@_DYrD[n"
+                "$ref": "http://1cHd22RCpb"
             },
-            "value": "enim tempor esse non"
+            "value": "dolore"
         },
         {
             "record": {
-                "$ref": "http://1`0)=jg "
+                "$ref": "http://12,`!tNn4e"
             },
-            "value": "aliquip dolore exercitation"
+            "value": "ea Ut"
         }
     ],
-    "control_number": -48814101,
+    "control_number": 54127130,
     "copyright": [
         {
-            "holder": "ipsum nisi quis consequat",
+            "holder": "dolore incididunt r",
             "material": "preprint",
-            "statement": "sed esse officia",
-            "url": "http://1bsQsrZ",
-            "year": 1650
+            "statement": "consequat eu",
+            "url": "http://1b'h)Z",
+            "year": 1534
         },
         {
-            "holder": "ut elit occaecat sit reprehenderit",
-            "material": "publication",
-            "statement": "in minim aliquip",
-            "url": "http://1?d{bW?.",
-            "year": 1736
+            "holder": "ullamco",
+            "material": "translation",
+            "statement": "cupidatat quis amet incididunt pariatur",
+            "url": "http://1\\",
+            "year": 1289
+        },
+        {
+            "holder": "laborum esse Ut reprehenderit cupidatat",
+            "material": "preprint",
+            "statement": "incididunt",
+            "url": "http://18KTrig*",
+            "year": 1574
         }
     ],
-    "core": true,
+    "core": false,
     "corporate_author": [
-        "nisi sed Duis occaecat",
-        "in et eiusmod",
-        "dolor dolore sint amet",
-        "fugiat officia irure in Ut",
-        "sit enim sint ea"
+        "occaecat",
+        "sit labore proident"
     ],
     "curated": true,
-    "deleted": false,
+    "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://1[^+"
+            "$ref": "http://1x"
         },
         {
-            "$ref": "http://1uBY"
+            "$ref": "http://1X"
         },
         {
-            "$ref": "http://1N'nY"
-        },
-        {
-            "$ref": "http://1)`1"
-        },
-        {
-            "$ref": "http://1Vk|(if0Vu"
+            "$ref": "http://1w~\\i<-"
         }
     ],
     "document_type": [
-        "activity report",
-        "report",
-        "proceedings",
-        "book chapter",
+        "thesis",
         "article"
     ],
     "documents": [
         {
-            "description": "Excepteur labore enim",
+            "description": "nisi velit fugiat",
             "fulltext": true,
-            "hidden": false,
-            "key": "dolore velit officia",
+            "hidden": true,
+            "key": "aliqua labore amet Ut pariatur",
             "material": "addendum",
-            "original_url": "http://1b!,P[~ty",
-            "source": "adipisicing proident",
-            "url": "http://1"
+            "original_url": "http://13j~ottN",
+            "source": "es",
+            "url": "http://132X(S?@\\I<"
+        },
+        {
+            "description": "nisi",
+            "fulltext": false,
+            "hidden": true,
+            "key": "exercitation dolore culpa do elit",
+            "material": "reprint",
+            "original_url": "http://1Tc_; =",
+            "source": "in ipsum ullamco",
+            "url": "http://1Tv_\\ ;@be"
+        },
+        {
+            "description": "magna in sunt Ut",
+            "fulltext": false,
+            "hidden": true,
+            "key": "deserunt dolore ullamco non sed",
+            "material": "editorial note",
+            "original_url": "http://1mLo\"IM9S=",
+            "source": "in adipisicing",
+            "url": "http://1]R0#,%2e=u"
         }
     ],
     "dois": [
         {
-            "material": "addendum",
-            "source": "veniam amet deserunt aute sunt",
-            "value": "10.4474244/t"
+            "material": "preprint",
+            "source": "reprehenderi",
+            "value": "10.126366/DDr,g"
         },
         {
-            "material": "addendum",
-            "source": "commodo cillum Excepteur et",
-            "value": "10.805473/IG'<B"
+            "material": "reprint",
+            "source": "dolor labore officia",
+            "value": "10.401654980/Eq3R<$Ej/vl"
+        },
+        {
+            "material": "publication",
+            "source": "ad",
+            "value": "10.3/:mzuNciA"
         }
     ],
     "editions": [
-        "magna aliqua",
-        "quis",
-        "nulla deserunt",
-        "esse ipsum",
-        "ad in sunt"
+        "nulla ex",
+        "laboris pariatur dolore",
+        "magna incididunt est qui anim"
     ],
     "energy_ranges": [
-        "30-100 GeV",
-        "100-300 GeV",
-        "> 10 TeV",
-        "1-10 TeV"
+        "100-300 GeV"
     ],
     "external_system_identifiers": [
         {
-            "schema": "in eu aliqua",
-            "value": "ullamco ea"
+            "schema": "ut quis ipsum",
+            "value": "ut laboris sint"
         },
         {
-            "schema": "sint ea ut pariatur consequat",
-            "value": "eu do culpa aut"
+            "schema": "sunt ut laboris nostrud reprehenderit",
+            "value": "nulla qui eu aliqua"
+        },
+        {
+            "schema": "adipisicing dolor quis ut est",
+            "value": "ad magna aute officia"
+        },
+        {
+            "schema": "cupidatat aute",
+            "value": "sit dolor ex"
+        },
+        {
+            "schema": "occaecat incididunt",
+            "value": "cillum dolore Excepteur eiusmod culpa"
         }
     ],
     "figures": [
         {
-            "caption": "anim amet eli",
-            "key": "aute nostrud exercitation",
-            "label": "enim",
+            "caption": "in voluptate dolore sunt eiusmod",
+            "key": "fugiat consectetur sed adipisicing cillum",
+            "label": "ad eiusmod est",
+            "material": "erratum",
+            "source": "deserunt eu id",
+            "url": "http://1(v2ETQ"
+        },
+        {
+            "caption": "in",
+            "key": "sit id ut commodo quis",
+            "label": "amet fugiat",
             "material": "addendum",
-            "source": "in sint",
-            "url": "http://1?"
+            "source": "proident",
+            "url": "http://1tu"
         }
     ],
     "funding_info": [
         {
-            "agency": "magna dolore dolor aliquip",
-            "grant_number": "deserunt mollit",
-            "project_number": "consequat"
+            "agency": "laborum dolore deserunt sint Lorem",
+            "grant_number": "irure",
+            "project_number": "labore dolor fugiat est ut"
         },
         {
-            "agency": "Ut non et",
-            "grant_number": "deserunt",
-            "project_number": "proident"
+            "agency": "eu in dolor",
+            "grant_number": "magna dolor consequat nostrud",
+            "project_number": "Lorem aliqua pariatur in deserunt"
+        },
+        {
+            "agency": "officia esse ullamco aliqua",
+            "grant_number": "deserunt dolore",
+            "project_number": "magna sint consequat"
         }
     ],
     "imprints": [
         {
-            "date": "2291-06-58",
-            "place": "proident voluptate in",
-            "publisher": "sit sint laboris consequat"
-        },
-        {
-            "date": "9108-91-16",
-            "place": "anim dolore in fugiat in",
-            "publisher": "veniam"
-        },
-        {
-            "date": "9702-78-86",
-            "place": "non reprehenderit nisi minim qui",
-            "publisher": "eiusmod enim commodo"
+            "date": "2002-01-06",
+            "place": "Lorem ex",
+            "publisher": "eu"
         }
     ],
     "inspire_categories": [
         {
             "source": "magpie",
-            "term": "Experiment-HEP"
+            "term": "Other"
         },
         {
-            "source": "user",
-            "term": "Lattice"
+            "source": "arxiv",
+            "term": "Other"
         },
         {
             "source": "undefined",
-            "term": "Astrophysics"
+            "term": "Phenomenology-HEP"
         },
         {
-            "source": "magpie",
-            "term": "Accelerators"
+            "source": "user",
+            "term": "Gravitation and Cosmology"
+        },
+        {
+            "source": "undefined",
+            "term": "Experiment-Nucl"
         }
     ],
     "isbns": [
         {
+            "medium": "hardcover",
+            "value": "024X"
+        },
+        {
+            "medium": "online",
+            "value": "262279"
+        },
+        {
             "medium": "print",
-            "value": "18951"
+            "value": "72"
         },
         {
             "medium": "hardcover",
-            "value": "8208169877"
-        },
-        {
-            "medium": "print",
-            "value": "11"
-        },
-        {
-            "medium": "hardcover",
-            "value": "85186"
+            "value": "811824924X"
         }
     ],
     "keywords": [
         {
+            "schema": "PDG",
+            "source": "fugiat",
+            "value": "Duis"
+        },
+        {
+            "schema": "PACS",
+            "source": "irure ut labore Excepteur nulla",
+            "value": "veniam"
+        },
+        {
+            "schema": "PDG",
+            "source": "Duis qui reprehenderit",
+            "value": "laborum officia sint exercitation"
+        },
+        {
+            "schema": "JACOW",
+            "source": "eu consectetur mollit dolor commodo",
+            "value": "aliqua ullamco"
+        },
+        {
             "schema": "INSPIRE",
-            "source": "Duis nostrud pariatu",
-            "value": "culpa commodo laboris"
+            "source": "Duis culpa proident",
+            "value": "in occaecat magna"
         }
     ],
     "languages": [
-        "fr",
-        "nl",
-        "el"
+        "ng",
+        "kg"
     ],
-    "legacy_creation_date": "4266-02-18T11:08:41.909Z",
+    "legacy_creation_date": "1975-09-21",
     "license": [
         {
-            "imposing": "sit velit",
-            "license": "dolor",
+            "imposing": "sunt tempor Duis amet ut",
+            "license": "dolore ex ipsum",
+            "material": "translation",
+            "url": "http://1_"
+        },
+        {
+            "imposing": "voluptate commodo nostrud tem",
+            "license": "",
+            "material": "preprint",
+            "url": "http://1o"
+        },
+        {
+            "imposing": "eiusmod cupidatat aliquip laborum laboris",
+            "license": "in",
             "material": "erratum",
-            "url": "http://1'^"
+            "url": "http://1* JgF-wFtS"
+        },
+        {
+            "imposing": "do",
+            "license": "dolor in ex",
+            "material": "preprint",
+            "url": "http://1Y"
         }
     ],
     "new_record": {
-        "$ref": "http://1}"
+        "$ref": "http://179.\"K'p)mg"
     },
-    "number_of_pages": 9901102,
+    "number_of_pages": 30699287,
     "persistent_identifiers": [
         {
-            "material": "translation",
+            "material": "reprint",
             "schema": "URN",
-            "source": "culpa mollit do sint",
-            "value": "voluptate incididunt i"
+            "source": "dolor occaecat",
+            "value": "incididunt voluptate"
         },
         {
-            "material": "erratum",
-            "schema": "URN",
-            "source": "magna veniam quis",
-            "value": "Lorem"
-        },
-        {
-            "material": "erratum",
-            "schema": "URN",
-            "source": "ut no",
-            "value": "ut nisi sit enim"
-        },
-        {
-            "material": "translation",
-            "schema": "URN",
-            "source": "Lorem mollit ut",
-            "value": "sunt cillum commodo nisi dolor"
-        },
-        {
-            "material": "publication",
-            "schema": "URN",
-            "source": "aliquip anim mollit",
-            "value": "non "
+            "material": "editorial note",
+            "schema": "HDL",
+            "source": "amet in",
+            "value": "consectetur est"
         }
     ],
-    "preprint_date": "8585-13-13",
+    "preprint_date": "1984-04-30",
     "public_notes": [
         {
-            "source": "elit dolor nostrud",
-            "value": "nostrud ut officia ea"
+            "source": "est velit aliquip",
+            "value": "in sunt"
         },
         {
-            "source": "d",
-            "value": "magna"
-        },
-        {
-            "source": "deserunt proident",
-            "value": "irure pariatur"
-        },
-        {
-            "source": "labore Duis",
-            "value": "reprehenderit et adipisicing dolor"
+            "source": "sit voluptate Excepteur laboris",
+            "value": "dolore do elit"
         }
     ],
     "publication_info": [
         {
-            "artid": "sit eiusmod tempor consectetur consequat",
-            "cnum": "C63-48-38",
-            "conf_acronym": "mollit cons",
+            "artid": "adipisicing ut",
+            "cnum": "C64-30-40",
+            "conf_acronym": "sit id proident non",
             "conference_record": {
-                "$ref": "http://1$"
+                "$ref": "http://1a%"
+            },
+            "curated_relation": true,
+            "hidden": true,
+            "journal_issue": "eiusmod consectetur velit labore",
+            "journal_record": {
+                "$ref": "http://1jLUvM{S"
+            },
+            "journal_title": "consequat",
+            "journal_volume": "irure Ut",
+            "material": "preprint",
+            "page_end": "enim Lorem laboris",
+            "page_start": "incididunt sit consectetur sunt Lore",
+            "parent_isbn": "2321061939",
+            "parent_record": {
+                "$ref": "http://1(7.|<MB>"
+            },
+            "parent_report_number": "eiusmod",
+            "pubinfo_freetext": "nostrud",
+            "year": 1348
+        },
+        {
+            "artid": "elit nulla id cupidatat nostrud",
+            "cnum": "C78-99-06.93726",
+            "conf_acronym": "esse",
+            "conference_record": {
+                "$ref": "http://1sqv+cM"
+            },
+            "curated_relation": true,
+            "hidden": true,
+            "journal_issue": "deserunt Ut nulla aute",
+            "journal_record": {
+                "$ref": "http://154"
+            },
+            "journal_title": "consequat sunt sit",
+            "journal_volume": "do qui exercitation Lorem Ut",
+            "material": "preprint",
+            "page_end": "officia consectetur",
+            "page_start": "veniam",
+            "parent_isbn": "92348907",
+            "parent_record": {
+                "$ref": "http://1V%,'UX"
+            },
+            "parent_report_number": "esse dolore",
+            "pubinfo_freetext": "reprehende",
+            "year": 1069
+        },
+        {
+            "artid": "incididunt anim esse labore",
+            "cnum": "C77-94-88",
+            "conf_acronym": "voluptate est qui in",
+            "conference_record": {
+                "$ref": "http://1|"
             },
             "curated_relation": false,
             "hidden": false,
-            "journal_issue": "ut enim nostrud",
+            "journal_issue": "sunt deserunt cupid",
             "journal_record": {
-                "$ref": "http://1&"
+                "$ref": "http://1W"
             },
-            "journal_title": "dolore est",
-            "journal_volume": "occaecat",
+            "journal_title": "anim ullamco nulla labore",
+            "journal_volume": "sed aliqua dolore",
             "material": "addendum",
-            "page_end": "consequat aut",
-            "page_start": "reprehenderit dolore",
-            "parent_isbn": "9794000361740",
+            "page_end": "adipisici",
+            "page_start": "esse dolor non anim",
+            "parent_isbn": "41",
             "parent_record": {
-                "$ref": "http://16JXr\"mK"
+                "$ref": "http://1VP"
             },
-            "parent_report_number": "Duis qui exercitation laborum aliquip",
-            "pubinfo_freetext": "officia magna",
-            "year": 1274
+            "parent_report_number": "elit dolor Ut consectetur eiusmod",
+            "pubinfo_freetext": "cupidatat veniam lab",
+            "year": 1603
+        },
+        {
+            "artid": "irure ea",
+            "cnum": "C27-90-97",
+            "conf_acronym": "ut",
+            "conference_record": {
+                "$ref": "http://1zQO"
+            },
+            "curated_relation": true,
+            "hidden": true,
+            "journal_issue": "consectetur commodo esse labore in",
+            "journal_record": {
+                "$ref": "http://1A0"
+            },
+            "journal_title": "reprehenderit",
+            "journal_volume": "ea enim",
+            "material": "publication",
+            "page_end": "ut non",
+            "page_start": "cillum sit culpa labore",
+            "parent_isbn": "89142",
+            "parent_record": {
+                "$ref": "http://1siN9H^ x"
+            },
+            "parent_report_number": "adipisicing",
+            "pubinfo_freetext": "Lorem Duis Excepteur",
+            "year": 1769
+        },
+        {
+            "artid": "deserunt incididunt commodo sint",
+            "cnum": "C71-40-75.5773136826",
+            "conf_acronym": "id nulla sit reprehenderit",
+            "conference_record": {
+                "$ref": "http://1:5xf"
+            },
+            "curated_relation": false,
+            "hidden": true,
+            "journal_issue": "do",
+            "journal_record": {
+                "$ref": "http://1CD<Lqvz/3b"
+            },
+            "journal_title": "consectetur ",
+            "journal_volume": "pariatur veniam nisi id in",
+            "material": "translation",
+            "page_end": "dolor",
+            "page_start": "cupidatat",
+            "parent_isbn": "55632402009",
+            "parent_record": {
+                "$ref": "http://1p9"
+            },
+            "parent_report_number": "incididunt non",
+            "pubinfo_freetext": "eiusmod labore aute cillum",
+            "year": 1460
         }
     ],
     "publication_type": [
-        "review",
-        "review"
+        "lectures",
+        "introductory"
     ],
     "record_affiliations": [
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1S4c~9.B'"
+                "$ref": "http://1KF[=9"
             },
-            "value": "in id"
+            "value": "id anim tempor aliqua"
         },
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1Zk"
+                "$ref": "http://1I4O}a=Dt["
             },
-            "value": "aute laboris culpa"
+            "value": "es"
         },
         {
-            "curated_relation": false,
+            "curated_relation": true,
             "record": {
-                "$ref": "http://1FaAU| (t+"
+                "$ref": "http://1nO"
             },
-            "value": "commodo"
+            "value": "officia esse qui"
+        },
+        {
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://1"
+            },
+            "value": "labore"
         }
     ],
     "refereed": true,
     "references": [
         {
-            "curated_relation": false,
-            "raw_refs": [
-                {
-                    "schema": "incididunt",
-                    "source": "aute proident consectetur",
-                    "value": "in cillum qui"
-                }
-            ],
-            "record": {
-                "$ref": "http://1z5-|"
-            },
-            "reference": {
-                "arxiv_eprint": "1378K02889",
-                "authors": [
-                    {
-                        "full_name": "officia laborum",
-                        "inspire_role": "supervisor"
-                    }
-                ],
-                "book_series": {
-                    "title": "fugiat quis consequat qui consectetur",
-                    "volume": "velit ipsum tempor"
-                },
-                "collaborations": [
-                    "nostrud dolore",
-                    "dolore in",
-                    "l"
-                ],
-                "document_type": "report",
-                "dois": [
-                    "10.45448.2537221/AG"
-                ],
-                "imprint": {
-                    "date": "1030-70-92",
-                    "place": "ea",
-                    "publisher": "reprehenderit ex non"
-                },
-                "isbn": "085",
-                "label": "amet et si",
-                "misc": [
-                    "commodo sed sunt ex",
-                    "nostrud quis",
-                    "exercitation cupidatat enim laborum",
-                    "eiusmo",
-                    "magna velit"
-                ],
-                "persistent_identifiers": [
-                    {
-                        "schema": "URN",
-                        "value": "in dolore"
-                    }
-                ],
-                "publication_info": {
-                    "artid": "dolore do",
-                    "cnum": "C07-73-69.3500173477",
-                    "journal_issue": "incididunt id sit",
-                    "journal_title": "et",
-                    "journal_volume": "proident ea commodo",
-                    "material": "publication",
-                    "page_end": "Lorem laboris labore",
-                    "page_start": "aliquip irure",
-                    "parent_isbn": "2472820462",
-                    "parent_report_number": "aliqua sint",
-                    "parent_title": "",
-                    "year": 1698
-                },
-                "report_numbers": [
-                    "tempor nulla adipisicing consectetur"
-                ],
-                "texkey": "ullamco dolor esse quis",
-                "title": {
-                    "source": "reprehenderit nisi ut non nulla",
-                    "subtitle": "anim nulla labore et",
-                    "title": "eu consectetur"
-                },
-                "urls": [
-                    {
-                        "description": "nisi Duis proident",
-                        "value": "http://1f<?.M"
-                    },
-                    {
-                        "description": "Excepteur",
-                        "value": "http://1G"
-                    }
-                ]
-            }
-        },
-        {
-            "curated_relation": false,
-            "raw_refs": [
-                {
-                    "schema": "ea eiusmod sed",
-                    "source": "Lorem magna ea",
-                    "value": "laboris veniam aliqua"
-                },
-                {
-                    "schema": "nisi dolor sit mollit sunt",
-                    "source": "elit qui fugiat do et",
-                    "value": "proident"
-                },
-                {
-                    "schema": "nisi in commodo in",
-                    "source": "magna voluptate nostrud",
-                    "value": "velit irure"
-                }
-            ],
-            "record": {
-                "$ref": "http://1k>{zmj"
-            },
-            "reference": {
-                "arxiv_eprint": "h8R976s-9EOWR1FnchP/8533557083",
-                "authors": [
-                    {
-                        "full_name": "in fugiat",
-                        "inspire_role": "editor"
-                    },
-                    {
-                        "full_name": "et laborum",
-                        "inspire_role": "editor"
-                    },
-                    {
-                        "full_name": "sunt",
-                        "inspire_role": "author"
-                    },
-                    {
-                        "full_name": "laborum ipsum non do sint",
-                        "inspire_role": "author"
-                    },
-                    {
-                        "full_name": "ut",
-                        "inspire_role": "supervisor"
-                    }
-                ],
-                "book_series": {
-                    "title": "ullamco dolore dolor adipisicing laborum",
-                    "volume": "nisi"
-                },
-                "collaborations": [
-                    "dolore proident minim consectetu"
-                ],
-                "document_type": "note",
-                "dois": [
-                    "10.02/Mt+@{"
-                ],
-                "imprint": {
-                    "date": "3124-76-67",
-                    "place": "sunt sint",
-                    "publisher": "occaecat"
-                },
-                "isbn": "8082594X",
-                "label": "labore do velit ut",
-                "misc": [
-                    "Duis Ut "
-                ],
-                "persistent_identifiers": [
-                    {
-                        "schema": "URN",
-                        "value": "minim dolor enim"
-                    },
-                    {
-                        "schema": "URN",
-                        "value": "aute culpa dolore mollit"
-                    },
-                    {
-                        "schema": "HDL",
-                        "value": "veniam ut"
-                    },
-                    {
-                        "schema": "HDL",
-                        "value": "in Ut"
-                    }
-                ],
-                "publication_info": {
-                    "artid": "sit",
-                    "cnum": "C17-41-25",
-                    "journal_issue": "dolor cillum esse",
-                    "journal_title": "ex minim",
-                    "journal_volume": "est ea qui Excepteur",
-                    "material": "erratum",
-                    "page_end": "dolor eu ea",
-                    "page_start": "aute eu incid",
-                    "parent_isbn": "4484",
-                    "parent_report_number": "Duis occaecat eiusmod nulla magna",
-                    "parent_title": "exercitation",
-                    "year": 1983
-                },
-                "report_numbers": [
-                    "dolore et"
-                ],
-                "texkey": "voluptate Excepteur ",
-                "title": {
-                    "source": "aliquip incididunt irure",
-                    "subtitle": "dolor",
-                    "title": "nulla velit enim irure"
-                },
-                "urls": [
-                    {
-                        "description": "sunt do reprehenderit sint ipsum",
-                        "value": "http://1]j"
-                    },
-                    {
-                        "description": "in nostrud deserunt officia",
-                        "value": "http://16"
-                    },
-                    {
-                        "description": "veniam consequat magna",
-                        "value": "http://1{&GT{$"
-                    },
-                    {
-                        "description": "minim voluptate Lorem commodo adip",
-                        "value": "http://1(O"
-                    },
-                    {
-                        "description": "mollit ex minim est",
-                        "value": "http://1"
-                    }
-                ]
-            }
-        },
-        {
             "curated_relation": true,
             "raw_refs": [
                 {
-                    "schema": "Lorem",
-                    "source": "cillum laboris ad esse",
-                    "value": "amet nisi magna ut ven"
+                    "schema": "ex",
+                    "source": "si",
+                    "value": "velit cupidatat"
                 },
                 {
-                    "schema": "nulla ut pariatur",
-                    "source": "est Duis nulla reprehenderit",
-                    "value": "anim adipisici"
+                    "schema": "aliqua magna in tempor ullamco",
+                    "source": "adipisicing ex occaecat s",
+                    "value": "dolore laborum exercitation labore ut"
+                },
+                {
+                    "schema": "Excepteur id ipsum Ut fugiat",
+                    "source": "non dolor",
+                    "value": "Duis Ut"
+                },
+                {
+                    "schema": "Ut deserunt enim",
+                    "source": "tempor in",
+                    "value": "Lorem adipisicing aliquip ullamco exercitation"
+                },
+                {
+                    "schema": "Lorem ut",
+                    "source": "irure laboris Lorem mollit",
+                    "value": "deserunt ullamco esse commodo"
                 }
             ],
             "record": {
-                "$ref": "http://1,.LI"
+                "$ref": "http://13"
             },
             "reference": {
-                "arxiv_eprint": "4/831",
+                "arxiv_eprint": "5336^74160",
                 "authors": [
                     {
-                        "full_name": "exercitation",
+                        "full_name": "occaecat exercitation",
+                        "inspire_role": "author"
+                    },
+                    {
+                        "full_name": "labore non",
+                        "inspire_role": "author"
+                    },
+                    {
+                        "full_name": "Excepteur",
                         "inspire_role": "editor"
-                    },
-                    {
-                        "full_name": "sit esse Lorem q",
-                        "inspire_role": "supervisor"
-                    },
-                    {
-                        "full_name": "in ut dolore fugiat occaecat",
-                        "inspire_role": "editor"
-                    },
-                    {
-                        "full_name": "adipisicing cupidatat enim in",
-                        "inspire_role": "supervisor"
                     }
                 ],
                 "book_series": {
-                    "title": "adipisicing eu",
-                    "volume": "non ullamco aute quis"
+                    "title": "officia veniam adipisicing",
+                    "volume": "in deserunt"
                 },
                 "collaborations": [
-                    "est amet ea"
+                    "proident ut",
+                    "nulla magna dolore ex ut",
+                    "veniam ipsum aliqua sunt esse"
                 ],
-                "document_type": "book chapter",
+                "document_type": "article",
                 "dois": [
-                    "10.49165/5K",
-                    "10.583369.40525/7+}tpn,]V3",
-                    "10.6298754706/PDi;",
-                    "10.466/J)b[Bg",
-                    "10.6494/1Pa^CB#S4vc"
+                    "10.13.61577737/Et=&}?",
+                    "10.185276750/Z^R"
                 ],
                 "imprint": {
-                    "date": "4028-16-88",
-                    "place": "ullamco ame",
-                    "publisher": "ut anim"
+                    "date": "1992-10-19",
+                    "place": "proident pariatur officia irure ut",
+                    "publisher": "exercitation occaecat culpa"
                 },
-                "isbn": "956163263",
-                "label": "sed nostrud sunt aliquip",
+                "isbn": "33774606",
+                "label": "ex labore sunt",
                 "misc": [
-                    "ex commodo irure cupidatat",
-                    "sed sit eiusmod ipsum",
-                    "do",
-                    "consequat ma"
+                    "aliquip mollit",
+                    "sed mollit non dolor",
+                    "conse",
+                    "irure dolore",
+                    "Excepteur enim ad"
                 ],
                 "persistent_identifiers": [
                     {
-                        "schema": "URN",
-                        "value": "elit occaecat ipsum"
+                        "schema": "HDL",
+                        "value": "nisi nostrud quis veniam ut"
                     },
                     {
                         "schema": "HDL",
-                        "value": "voluptate culpa dolore"
-                    },
-                    {
-                        "schema": "HDL",
-                        "value": "in mollit in"
-                    },
-                    {
-                        "schema": "HDL",
-                        "value": "aliquip reprehenderit velit eu"
+                        "value": "mollit"
                     },
                     {
                         "schema": "URN",
-                        "value": "est velit minim adipisicing"
+                        "value": "dolor veniam ad"
+                    },
+                    {
+                        "schema": "URN",
+                        "value": "ad dolor laborum officia Duis"
                     }
                 ],
                 "publication_info": {
-                    "artid": "id eu quis pariatur",
-                    "cnum": "C36-64-82.59637",
-                    "journal_issue": "velit proident",
-                    "journal_title": "dolore",
-                    "journal_volume": "fugiat consectetur irure magna dolore",
-                    "material": "translation",
-                    "page_end": "minim",
-                    "page_start": "dolor",
-                    "parent_isbn": "45083449",
-                    "parent_report_number": "cupidatat officia incididunt minim",
-                    "parent_title": "officia elit magna irure",
-                    "year": 1565
+                    "artid": "aliqua pariatur",
+                    "cnum": "C89-75-68",
+                    "journal_issue": "quis nisi adipisici",
+                    "journal_title": "fug",
+                    "journal_volume": "minim irure",
+                    "material": "reprint",
+                    "page_end": "ipsum ullamco dolore reprehenderit",
+                    "page_start": "laboris",
+                    "parent_isbn": "X",
+                    "parent_report_number": "in in est",
+                    "parent_title": "nisi quis",
+                    "year": 1287
                 },
                 "report_numbers": [
-                    "commodo"
+                    "dolore elit eu reprehenderit ut"
                 ],
-                "texkey": "non laboris do aliqua ullamco",
+                "texkey": "nostrud amet",
                 "title": {
-                    "source": "dolor",
-                    "subtitle": "sint in elit amet pariatur",
-                    "title": "ex labore in ut"
+                    "source": "est Lorem ea aute",
+                    "subtitle": "dolore eiusmod adipisicing mollit nostru",
+                    "title": "nostrud labore Excepteur"
                 },
                 "urls": [
                     {
-                        "description": "quis",
-                        "value": "http://1b:"
+                        "description": "anim in nostrud ut magn",
+                        "value": "http://1"
                     },
                     {
-                        "description": "sit amet",
-                        "value": "http://1$x^t;~"
-                    },
-                    {
-                        "description": "aliquip velit",
-                        "value": "http://1s1T@2cB>@"
-                    },
-                    {
-                        "description": "reprehenderit ea",
-                        "value": "http://1\"&BP&vCa"
-                    },
-                    {
-                        "description": "aute fugiat",
-                        "value": "http://1qS"
+                        "description": "ea in ut dolore",
+                        "value": "http://1+CX-?M+"
                     }
                 ]
             }
@@ -1289,126 +1195,139 @@
     ],
     "related_records": [
         {
+            "curated_relation": false,
             "record": {
-                "$ref": "http://1r|j"
+                "$ref": "http://1) #(9%#"
             },
-            "relation": "parent"
+            "relation": "predecessor",
+            "relation_freetext": "aute incididunt"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1j'<]"
+            },
+            "relation": "commented",
+            "relation_freetext": "Lorem"
+        },
+        {
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://1u,YUG"
+            },
+            "relation": "parent",
+            "relation_freetext": "tempor consectetur sunt"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1+qU*AO/Er0"
+            },
+            "relation": "predecessor",
+            "relation_freetext": "fugiat esse no"
+        },
+        {
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://1{t"
+            },
+            "relation": "parent",
+            "relation_freetext": "in est in do"
         }
     ],
     "report_numbers": [
         {
             "hidden": true,
-            "source": "aliquip aliqua ullamco laboris adipis",
-            "value": "occaecat proident labore cupidatat non"
+            "source": "ea",
+            "value": "tempor"
+        },
+        {
+            "hidden": true,
+            "source": "Ut incididunt fugiat sed",
+            "value": "est"
+        },
+        {
+            "hidden": false,
+            "source": "do",
+            "value": "do"
+        },
+        {
+            "hidden": true,
+            "source": "dolor sint ea",
+            "value": "aliqu"
+        },
+        {
+            "hidden": false,
+            "source": "anim esse sed irure proident",
+            "value": "proident sunt occaecat"
         }
     ],
     "self": {
-        "$ref": "http://1@F|-:(pM&"
+        "$ref": "http://1Fc"
     },
     "texkeys": [
-        "velit magna in reprehe",
-        "Duis tempor in",
-        "veniam incididunt te",
-        "in deserunt",
-        "sed"
+        "incid",
+        "sunt"
     ],
     "thesis_info": {
-        "date": "3075-70-76",
-        "defense_date": "2614-81-28",
-        "degree_type": "habilitation",
+        "date": "2018-10-27",
+        "defense_date": "1992-04-05",
+        "degree_type": "diploma",
         "institutions": [
             {
-                "curated_relation": true,
-                "name": "exercitation",
-                "record": {
-                    "$ref": "http://1vs8h~v`n"
-                }
-            },
-            {
-                "curated_relation": true,
-                "name": "culpa ut eu",
-                "record": {
-                    "$ref": "http://1#M"
-                }
-            },
-            {
                 "curated_relation": false,
-                "name": "adipisicing Duis qui",
+                "name": "velit commodo do",
                 "record": {
-                    "$ref": "http://1|;i&sg[o4Q"
-                }
-            },
-            {
-                "curated_relation": false,
-                "name": "nulla amet",
-                "record": {
-                    "$ref": "http://1Hk4<K79I]b"
+                    "$ref": "http://1lx."
                 }
             }
         ]
     },
     "title_translations": [
         {
-            "language": "la",
-            "source": "culpa ipsum ut minim sunt",
-            "subtitle": "aute",
-            "title": "ad reprehenderit aliqua"
+            "language": "fi",
+            "source": "aute ex ",
+            "subtitle": "Ut do veniam minim laboris",
+            "title": "id et veniam minim"
         },
         {
-            "language": "es",
-            "source": "nostrud amet",
-            "subtitle": "quis",
-            "title": "Exc"
+            "language": "pl",
+            "source": "dolore",
+            "subtitle": "Lorem adipisicing ipsum",
+            "title": "ut non anim"
         },
         {
-            "language": "la",
-            "source": "reprehenderit dolor laboris",
-            "subtitle": "Lorem ullamco officia do",
-            "title": "te"
+            "language": "sk",
+            "source": "adipisicing dolore dolor",
+            "subtitle": "incididunt quis culpa laborum",
+            "title": "am"
         }
     ],
     "titles": [
         {
-            "source": "Ut ipsum qui Lorem",
-            "subtitle": "do elit consequat",
-            "title": "cillum proident ad reprehenderit est"
+            "source": "dolore in",
+            "subtitle": "pariatur culpa nulla fugiat",
+            "title": "laborum dolor quis"
         },
         {
-            "source": "consequat mollit",
-            "subtitle": "ullamco Duis ad elit voluptate",
-            "title": "ipsum minim sunt"
+            "source": "tempor Lorem anim aliqua",
+            "subtitle": "consequa",
+            "title": "tempor anim nu"
         },
         {
-            "source": "fugiat veniam Lorem mollit culpa",
-            "subtitle": "do anim",
-            "title": "eu"
-        },
-        {
-            "source": "laborum",
-            "subtitle": "occaecat quis ad",
-            "title": "nulla occaecat non incididunt cillum"
+            "source": "in enim exercitation fugiat",
+            "subtitle": "velit deserunt aliquip ea nulla",
+            "title": "tempor"
         }
     ],
     "urls": [
         {
-            "description": "in nulla ut laborum",
-            "value": "http://1jsmMmC"
+            "description": "anim in",
+            "value": "http://1gPEzmR"
         },
         {
-            "description": "mollit irure laboris dolore id",
-            "value": "http://1u"
-        },
-        {
-            "description": "laborum do anim elit",
-            "value": "http://1d"
-        },
-        {
-            "description": "veniam ips",
-            "value": "http://16`l 1hH+C"
-        },
-        {
-            "description": "Excepteur aute sint dolore ipsum",
-            "value": "http://12_6"
+            "description": "mollit ad",
+            "value": "http://1L-,O]"
         }
     ],
     "withdrawn": true

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -1,157 +1,261 @@
 {
     "ICN": [
-        "velit",
-        "sunt in dolore quis ut",
-        "fugiat tempor dolor mollit",
-        "consequat qui"
+        "in incididunt qui veniam proident",
+        "qui adipisicing id aliqua Lorem"
     ],
     "_collections": [
         "Institutions"
     ],
     "_private_notes": [
         {
-            "source": "repreh",
-            "value": "anim"
-        },
-        {
-            "source": "fugiat consequat anim commodo",
-            "value": "laboris"
+            "source": "nisi ut ullamco Lorem dolor",
+            "value": "occaecat commodo"
         }
     ],
     "addresses": [
         {
             "cities": [
-                "minim cillum in est consectetur",
-                "voluptate laboris sunt pariatur incididunt",
-                "officia",
-                "nisi"
+                "labore do ullamco",
+                "adipisicing deserunt sunt ali",
+                "nisi deserunt eu cupidatat"
             ],
-            "country_code": "WS",
-            "latitude": -41202862,
-            "longitude": -61333400,
-            "place_name": "qui reprehenderit fugiat nostrud",
+            "country_code": "CF",
+            "latitude": 96958276,
+            "longitude": 58308717,
+            "place_name": "anim nulla in",
             "postal_address": [
-                "ut",
-                "Lorem",
-                "ipsum dolor deserunt in non"
+                "pariatur id sint irure in",
+                "minim aliquip cillum eiusmod officia"
             ],
-            "postal_code": "sed mollit nisi dolor ipsum",
-            "state": "in"
+            "postal_code": "esse ut",
+            "state": "eu quis commodo nisi"
+        },
+        {
+            "cities": [
+                "consectetur nulla quis"
+            ],
+            "country_code": "IS",
+            "latitude": -14558297,
+            "longitude": 55541699,
+            "place_name": "labore",
+            "postal_address": [
+                "sed laborum enim elit",
+                "enim est amet dolore ",
+                "elit nostrud eiusmod",
+                "aliquip Duis ipsum",
+                "sunt ut in adipisicing"
+            ],
+            "postal_code": "paria",
+            "state": "dolor dolor"
+        },
+        {
+            "cities": [
+                "nisi mollit dolore",
+                "ipsum"
+            ],
+            "country_code": "KZ",
+            "latitude": 65627536,
+            "longitude": -93715142,
+            "place_name": "tempor",
+            "postal_address": [
+                "ani",
+                "esse aute eu adipisicing nulla",
+                "irure officia sed tempor anim"
+            ],
+            "postal_code": "ea irure incididunt anim",
+            "state": "deserunt et ipsum mollit"
+        },
+        {
+            "cities": [
+                "in labore sed labo"
+            ],
+            "country_code": "NU",
+            "latitude": 80630464,
+            "longitude": -58695324,
+            "place_name": "cillum cupidatat sed Lorem in",
+            "postal_address": [
+                "sed rep",
+                "dolor cupidatat labore dolore aliqua",
+                "offi",
+                "sed elit",
+                "ad"
+            ],
+            "postal_code": "exercita",
+            "state": "voluptate quis sed consequat"
+        },
+        {
+            "cities": [
+                "ex nostrud fugiat",
+                "qui ad ipsum pariatur sint",
+                "ut",
+                "velit quis pariatur"
+            ],
+            "country_code": "MN",
+            "latitude": -76869123,
+            "longitude": 66796700,
+            "place_name": "cupidatat",
+            "postal_address": [
+                "nostrud adipisicing sint Duis",
+                "sint id nulla",
+                "ullamco"
+            ],
+            "postal_code": "est Duis in",
+            "state": "qui est"
         }
     ],
-    "control_number": 94075514,
-    "core": true,
-    "deleted": true,
+    "control_number": -1823737,
+    "core": false,
+    "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1u"
+            "$ref": "http://1k'lNb_e"
+        },
+        {
+            "$ref": "http://1?\\i"
+        },
+        {
+            "$ref": "http://1O"
+        },
+        {
+            "$ref": "http://1,4g"
+        },
+        {
+            "$ref": "http://11'O"
         }
     ],
     "external_system_identifiers": [
         {
-            "schema": "HAL",
-            "value": "8261"
+            "schema": "SPIRES",
+            "value": "INST-500"
         },
         {
-            "schema": "HAL",
-            "value": "3579214"
-        },
-        {
-            "schema": "HAL",
-            "value": "12728"
-        },
-        {
-            "schema": "HAL",
-            "value": "28936264786"
-        },
-        {
-            "schema": "HAL",
-            "value": "0419"
+            "schema": "SPIRES",
+            "value": "INST-64882508"
         }
     ],
     "extra_words": [
-        "ea occaecat ut deserunt",
-        "anim",
-        "amet laborum exercitation nulla anim",
-        "amet officia",
-        "deserunt ea mollit"
+        "in enim reprehenderit exercitation",
+        "mollit",
+        "dolor dolor eiusmod",
+        "in",
+        "nostrud commodo fugiat sint"
     ],
     "historical_data": [
-        "reprehende"
+        "officia",
+        "irure proident"
     ],
+    "inactive": true,
     "inspire_categories": [
         {
-            "source": "undefined",
-            "term": "Accelerators"
+            "source": "user",
+            "term": "Data Analysis and Statistics"
         },
         {
-            "source": "undefined",
-            "term": "Computing"
+            "source": "user",
+            "term": "Accelerators"
         }
     ],
     "institution_hierarchy": [
         {
-            "acronym": "oc",
-            "name": "sint irure sun"
+            "acronym": "in culpa reprehenderit c",
+            "name": "aliquip dolore nisi eiusmod"
         },
         {
-            "acronym": "minim non dolor quis",
-            "name": "eiusmod ea"
+            "acronym": "amet ad aliqua est nostr",
+            "name": "Lorem aliq"
         },
         {
-            "acronym": "incididunt commodo nulla enim anim",
-            "name": "commodo deserunt cillum reprehenderit"
+            "acronym": "in",
+            "name": "proid"
         },
         {
-            "acronym": "consectetur dolore in ea ipsum",
-            "name": "ex adipisicing ea est exercitation"
+            "acronym": "id aliqua in",
+            "name": "adipisicing"
         }
     ],
     "institution_type": [
-        "Other",
-        "Other"
+        "Research Center",
+        "University",
+        "Research Center"
     ],
-    "legacy_ICN": "commodo et",
-    "legacy_creation_date": "2485-08-11T06:36:12.003Z",
+    "legacy_ICN": "ut",
+    "legacy_creation_date": "1990-04-08",
     "name_variants": [
         {
-            "source": "proident in exercitation incididunt",
-            "value": ""
+            "source": "voluptate ipsum amet",
+            "value": "adipisicing sunt voluptate proident"
+        },
+        {
+            "source": "in ea",
+            "value": "dolore esse labore"
+        },
+        {
+            "source": "amet mollit",
+            "value": "Excepteur ullamco"
         }
     ],
     "new_record": {
-        "$ref": "http://1-@Cu"
+        "$ref": "http://1"
     },
     "public_notes": [
         {
-            "source": "commodo",
-            "value": "adipisicing et officia sunt"
+            "source": "velit elit",
+            "value": "ea nisi non "
         },
         {
-            "source": "ex",
-            "value": "anim qui cillum sed fugiat"
+            "source": "qui amet ullamco",
+            "value": "ad ut"
         },
         {
-            "source": "culpa quis Lorem",
-            "value": "ad"
+            "source": "laboris ut et id reprehenderit",
+            "value": "est "
         }
     ],
     "related_records": [
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1fN$n<R9"
+                "$ref": "http://1v3[%l"
             },
-            "relation_freetext": "nisi laborum mollit anim"
+            "relation": "commented",
+            "relation_freetext": "occaecat pariatur dolor laborum"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1[M"
+            },
+            "relation": "commented",
+            "relation_freetext": "esse ullamco"
+        },
+        {
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://14C8Es"
+            },
+            "relation": "commented",
+            "relation_freetext": "nisi"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1GU}312,j"
+            },
+            "relation": "commented",
+            "relation_freetext": "sed pariatur ut et ullamco"
         }
     ],
     "self": {
-        "$ref": "http://1\\2]1*0D"
+        "$ref": "http://1d.P{sX%`"
     },
     "urls": [
         {
-            "description": "eu aliqua dolore nulla",
-            "value": "http://1F-Z6x/`"
+            "description": "voluptate consequat Duis non minim",
+            "value": "http://1Q2P-)Y;IH8"
+        },
+        {
+            "description": "aliquip incididunt",
+            "value": "http://1!V6"
         }
     ]
 }

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -4,199 +4,259 @@
     ],
     "_private_notes": [
         {
-            "source": "tempor",
-            "value": "sit dese"
-        },
-        {
-            "source": "cupidatat",
-            "value": "mollit consequat incididunt irure"
-        },
-        {
-            "source": "fugiat eu aute",
-            "value": "sit veniam"
-        },
-        {
-            "source": "irure do Lorem",
-            "value": "veniam est incididunt"
+            "source": "proident ut minim eiusmod tempor",
+            "value": "tempor esse consequat in"
         }
     ],
     "address": [
         {
             "cities": [
-                "dolore fugiat dolor elit",
-                "ea"
+                "aliqua ut elit ut sit"
             ],
-            "country_code": "SS",
-            "latitude": 81848470,
-            "longitude": -72396005,
-            "place_name": "dolore",
+            "country_code": "EG",
+            "latitude": -27336000,
+            "longitude": -81125917,
+            "place_name": "veniam do officia",
             "postal_address": [
                 "voluptate"
             ],
-            "postal_code": "sunt deserunt amet",
-            "state": "id"
+            "postal_code": "pariatur quis dolore ad",
+            "state": "aliquip ea minim"
+        },
+        {
+            "cities": [
+                "qui labore enim",
+                "irure",
+                "irure minim dolor eu",
+                "tempor culpa ad"
+            ],
+            "country_code": "HT",
+            "latitude": 40472638,
+            "longitude": 45833465,
+            "place_name": "in nostrud Duis non ad",
+            "postal_address": [
+                "officia commodo id Ut consequat"
+            ],
+            "postal_code": "sed elit nulla fugiat",
+            "state": "amet"
+        },
+        {
+            "cities": [
+                "proident est esse sunt",
+                "deserunt magna nulla ea"
+            ],
+            "country_code": "NZ",
+            "latitude": 94242492,
+            "longitude": 35359188,
+            "place_name": "voluptate minim veniam laborum",
+            "postal_address": [
+                "dolor",
+                "consectetur elit",
+                "dolor velit veniam",
+                "nostrud",
+                "amet Ut id"
+            ],
+            "postal_code": "do adipisicing",
+            "state": "cillum"
+        },
+        {
+            "cities": [
+                "quis",
+                "dolore si",
+                "sunt commo"
+            ],
+            "country_code": "LC",
+            "latitude": 60777336,
+            "longitude": 90075683,
+            "place_name": "incididunt tempor reprehenderit",
+            "postal_address": [
+                "laboris incididunt in"
+            ],
+            "postal_code": "sunt in anim",
+            "state": "dolore est id"
+        },
+        {
+            "cities": [
+                "cupidatat et",
+                "ex"
+            ],
+            "country_code": "VN",
+            "latitude": 18844385,
+            "longitude": -32370459,
+            "place_name": "Lorem",
+            "postal_address": [
+                "commodo",
+                "incididunt aliquip ex et",
+                "commodo mollit ipsum elit dolore"
+            ],
+            "postal_code": "aliqua",
+            "state": "Excepteur Lorem"
         }
     ],
-    "closed_date": "dddd-dd-dd",
+    "closed_date": "2002-04-03",
     "contact_details": [
         {
-            "email": "Qz-eQ5ak@ZxgFrpvBteacHfJrpWchMGeoijI.yu",
-            "name": "magna commodo in"
+            "email": "AokS4bdkff1Z@pNKxpwYRJAjHO.en",
+            "name": "nisi dolor minim"
         },
         {
-            "email": "wVes9PAt0@pQNXHyxlzDibuEzQeMOG.bdn",
-            "name": "qui ad"
-        },
-        {
-            "email": "KV5@FgcijbRoEqKrAqjlxkQijgJkpTGyBNzEF.de",
-            "name": "sed elit"
-        },
-        {
-            "email": "7qO@DROTgVZxQBbPHkOhhaH.mqsr",
-            "name": "minim dolore qui"
+            "email": "i0-QJEp2xT@aiIVGQVJ.pfaz",
+            "name": "Ut Duis"
         }
     ],
-    "control_number": -9762397,
-    "deadline_date": "dddd-dd-dd",
+    "control_number": 38736310,
+    "deadline_date": "2013-03-06",
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1/4"
+            "$ref": "http://1,d'js1E~ u"
         },
         {
-            "$ref": "http://1\"\"]U}"
+            "$ref": "http://1fY\\u\\Sz8"
         },
         {
-            "$ref": "http://1{s:_lT"
+            "$ref": "http://1_bybs?yj"
         },
         {
-            "$ref": "http://1,@&==.&"
+            "$ref": "http://1jDD~"
         }
     ],
-    "description": "non nulla cupida",
+    "description": "sint conseq",
     "experiments": [
         {
-            "curated_relation": false,
-            "name": "nisi ad commodo enim mollit",
+            "curated_relation": true,
+            "name": "ut fugiat commodo tempor",
             "record": {
-                "$ref": "http://1>|$AG"
+                "$ref": "http://19)m$>`B"
             }
         },
         {
-            "curated_relation": true,
-            "name": "Lorem esse",
+            "curated_relation": false,
+            "name": "do minim aliqua veniam Duis",
             "record": {
-                "$ref": "http://19`R']+?a~b"
+                "$ref": "http://1kYq8%>y"
+            }
+        },
+        {
+            "curated_relation": false,
+            "name": "cillum magna id",
+            "record": {
+                "$ref": "http://1C2\\c:"
             }
         }
     ],
     "external_system_identifiers": [
         {
             "schema": "SPIRES",
-            "value": "JOBS-421"
-        },
-        {
-            "schema": "SPIRES",
-            "value": "JOBS-23087"
-        },
-        {
-            "schema": "SPIRES",
-            "value": "JOBS-3075"
+            "value": "JOBS-459"
         }
     ],
     "inspire_categories": [
         {
+            "source": "curator",
+            "term": "Computing"
+        },
+        {
+            "source": "undefined",
+            "term": "Theory-Nucl"
+        },
+        {
             "source": "magpie",
             "term": "Theory-Nucl"
+        },
+        {
+            "source": "magpie",
+            "term": "General Physics"
+        },
+        {
+            "source": "curator",
+            "term": "Experiment-Nucl"
         }
     ],
     "institutions": [
         {
             "curated_relation": true,
-            "name": "ipsum in cupidatat velit deserunt",
+            "name": "culpa",
             "record": {
-                "$ref": "http://1i557"
+                "$ref": "http://1)~pullY"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "est dolor velit",
+            "record": {
+                "$ref": "http://1 :Lq5Bht"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "consequat nos",
+            "record": {
+                "$ref": "http://1Ik(>"
+            }
+        },
+        {
+            "curated_relation": true,
+            "name": "velit",
+            "record": {
+                "$ref": "http://1&w"
             }
         },
         {
             "curated_relation": false,
-            "name": "quis dolore est laboris consequat",
+            "name": "Excepteur minim",
             "record": {
-                "$ref": "http://1H="
-            }
-        },
-        {
-            "curated_relation": false,
-            "name": "labore dolore",
-            "record": {
-                "$ref": "http://1F%L"
+                "$ref": "http://15!){(1"
             }
         }
     ],
-    "legacy_creation_date": "2843-01-23T00:39:44.604Z",
+    "legacy_creation_date": "1971-02-11",
     "new_record": {
-        "$ref": "http://1>"
+        "$ref": "http://13l}"
     },
-    "position": "cillum moll",
+    "position": "sit nulla",
     "public_notes": [
         {
-            "source": "nostrud cillum",
-            "value": "occaecat nulla Duis do ut"
+            "source": "Ut nostrud qui",
+            "value": "cillum minim dese"
         },
         {
-            "source": "labore Duis adipisicing dolor sunt",
-            "value": "in sit"
+            "source": "ex pariatur ullamco ipsum labore",
+            "value": "tempor nulla ea laborum"
         },
         {
-            "source": "nulla cupidatat velit Duis exercitation",
-            "value": "dolor ex aliquip elit sed"
+            "source": "velit dolor labore consectetur culpa",
+            "value": "offic"
         },
         {
-            "source": "est sit ut",
-            "value": "consectetur laborum"
+            "source": "id Excepteur",
+            "value": "anim"
         },
         {
-            "source": "anim aliquip dolore culpa",
-            "value": "ullamco Ut laboris"
+            "source": "commodo do amet sit",
+            "value": "elit anim adipisicing"
         }
     ],
     "ranks": [
-        "SENIOR",
         "PHD"
     ],
     "reference_email": [
-        "mXdfDWLMgfi@ihJvWvWNjKRUYeDpruUg.xfzt",
-        "V6qXjBbN178ThIT@AA.pxh",
-        "VhDo1JD5G@rdAYHiqehElseFuCqGFyPGoeBw.ruw",
-        "54ZvY6CZeXQpA31@NooNwazzqBusURpJYRVvtvtzhvuZ.atg",
-        "eFkWcjdsHbWfql@u.rswn"
+        "qeRNCV@iz.fg",
+        "10h1iYtlIW4ROxo@PTkLAbnLCDPxdeGVCsVOkfgqwgqmkfAbG.rge"
     ],
     "regions": [
-        "Middle East",
-        "Africa",
-        "South America",
+        "North America",
         "Europe",
+        "Middle East",
         "Middle East"
     ],
     "self": {
-        "$ref": "http://1Y"
+        "$ref": "http://1p?v<7U(7W"
     },
     "urls": [
         {
-            "description": "in exercitation aliquip ex dolor",
-            "value": "http://1byf"
-        },
-        {
-            "description": "minim ut",
-            "value": "http://1yY^bn"
-        },
-        {
-            "description": "in dolore est labore aute",
-            "value": "http://12YI"
-        },
-        {
-            "description": "enim ea qui dolore esse",
-            "value": "http://1k#T{'L"
+            "description": "amet labori",
+            "value": "http://1z.\".%-0.["
         }
     ]
 }

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -4,92 +4,93 @@
     ],
     "_harvesting_info": {
         "coverage": "partial",
-        "date_last_harvest": "8529-64-08",
-        "last_seen_item": "fugiat ullamco sit",
-        "method": "print"
+        "date_last_harvest": "2019-09-20",
+        "last_seen_item": "quis",
+        "method": "hepcrawl"
     },
     "_private_notes": [
         {
-            "source": "non",
-            "value": "cupidatat ut"
+            "source": "enim eiusmod consectetur",
+            "value": "amet nostrud dolore"
         },
         {
-            "source": "ex sit sed",
-            "value": "aute incididunt velit adipisicing"
-        },
-        {
-            "source": "veniam anim sed exercitation adipisicing",
-            "value": "eu fugiat"
-        },
-        {
-            "source": "qui laborum adipisicing reprehenderit",
-            "value": "irure"
-        },
-        {
-            "source": "quis cupidatat esse",
-            "value": "proident incididunt"
+            "source": "Excepteur",
+            "value": "ex dolore pariatur occaecat veniam"
         }
     ],
     "book_series": false,
-    "control_number": 37182727,
-    "date_ended": "6705-97-36",
-    "date_started": "2970-01-87",
+    "control_number": 35936268,
+    "date_ended": "2007-06-20",
+    "date_started": "2012-02-01",
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://18:R0OU"
+            "$ref": "http://1Q1kG(^qr }"
         },
         {
-            "$ref": "http://1iMc3p~/N(7"
+            "$ref": "http://1JSQu="
         }
     ],
     "doi_prefixes": [
-        "10.0027/dX0bFjrj.S",
-        "10.5053241.8297337446/\">?(z &+X?"
+        "10.0009911/AL0C{",
+        "10.49565959.50/\"z",
+        "10.35748684.54999017860/*Zx,F"
     ],
     "inspire_categories": [
         {
-            "source": "magpie",
-            "term": "General Physics"
+            "source": "arxiv",
+            "term": "Theory-Nucl"
         }
     ],
     "issns": [
         {
             "medium": "print",
-            "value": "8937-6658"
+            "value": "5409-0986"
+        },
+        {
+            "medium": "print",
+            "value": "1094-6289"
+        },
+        {
+            "medium": "online",
+            "value": "0007-4086"
         }
     ],
     "journal_title": {
-        "source": "quis",
-        "subtitle": "est",
-        "title": "irure laborum in labore ut"
+        "source": "anim est ut aliqua dolor",
+        "subtitle": "enim ullamco tempor veniam proident",
+        "title": "Duis"
     },
-    "legacy_creation_date": "0090-21-56",
+    "legacy_creation_date": "1970-01-15",
     "license": {
-        "license": "in exercitation",
-        "url": "http://1U"
+        "license": "consequat culpa ut",
+        "url": "http://1d%Zk;6myt"
     },
     "new_record": {
-        "$ref": "http://1"
+        "$ref": "http://1O`4>;Hd"
     },
     "proceedings": false,
     "public_notes": [
         {
-            "source": "cillum in",
-            "value": "sunt in"
+            "source": "ut irure et nisi cupidatat",
+            "value": "tempo"
         },
         {
-            "source": "culpa sint",
-            "value": "commodo cillum ex minim elit"
+            "source": "pariatur",
+            "value": "culpa"
         },
         {
-            "source": "commodo culpa",
-            "value": "in nostrud"
+            "source": "est id laboris",
+            "value": "non ea dolore"
+        },
+        {
+            "source": "commodo",
+            "value": "nostrud"
         }
     ],
     "publisher": [
-        "fugiat anim ad aliqua labore",
-        "anim qui officia"
+        "dolore irure ut sit",
+        "ex"
     ],
     "refereed": false,
     "related_records": [
@@ -98,24 +99,61 @@
             "record": {
                 "$ref": "http://1"
             },
+            "relation": "parent",
+            "relation_freetext": "irure nisi nulla dolor id"
+        },
+        {
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://1$0"
+            },
+            "relation": "commented",
+            "relation_freetext": "esse"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1xDBp"
+            },
+            "relation": "commented",
+            "relation_freetext": "laboris"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1WH4h"
+            },
+            "relation": "parent",
+            "relation_freetext": "irure laboris eiusmod id"
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://1(^L_`9~"
+            },
             "relation": "predecessor",
-            "relation_freetext": "et tempor"
+            "relation_freetext": "Lorem non est ullamco dolor"
         }
     ],
     "self": {
-        "$ref": "http://14\\\\["
+        "$ref": "http://1TC(XA_"
     },
-    "short_title": "irure labore ipsum quis velit",
+    "short_title": "sit aliqua culpa esse ad",
     "title_variants": [
-        "inci",
-        "dolore ea dolore sed",
-        "esse veniam occaecat do incididunt",
-        "amet magna et"
+        "non",
+        "anim occaecat",
+        "culpa",
+        "dolor",
+        "minim veniam tempor"
     ],
     "urls": [
         {
-            "description": "exercitation elit Ut sint magna",
-            "value": "http://1 %6AON5m"
+            "description": "ullamco dolore reprehenderit anim ipsum",
+            "value": "http://1"
+        },
+        {
+            "description": "id esse ut culpa",
+            "value": "http://1,%!mT.s\\~"
         }
     ]
 }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -79,3 +79,28 @@ def test_validate_raises_if_invalid_data():
 
     with pytest.raises(ValidationError):
         utils.validate(data, schema)
+
+
+def test_validate_accepts_partial_date():
+    data = '2017-02'
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'date',
+    }
+
+    utils.validate(data, schema)
+
+
+def test_validate_raises_on_invalid_date():
+    data = '2017-42',
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'date',
+    }
+
+    with pytest.raises(ValidationError):
+        utils.validate(data, schema)


### PR DESCRIPTION
* INCOMPATIBLE Extends the draft4 format checker to also validate
`format: date` (closes: #250).
* This also modifies the example generator script to produce real dates
by using `moment.js`.

Signed-off-by: Micha Moskovic <michamos@gmail.com>