### PR TITLE
hep.documents: make url required

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -876,21 +876,27 @@ class LiteratureBuilder(object):
     def add_figure(
         self,
         key,
+        url,
         caption=None,
         label=None,
         material=None,
         source=None,
-        url=None,
     ):
         """Add a figure."""
         figure = self._sourced_dict(source)
 
         if key:
             figure['key'] = key
+        else:
+            raise TypeError("Required argument 'key' should not be 'falsey'.")
+        if url:
+            figure['url'] = url
+        else:
+            raise TypeError("Required argument 'url' should not be 'falsey'.")
 
-        for key in ('caption', 'label', 'material', 'url'):
-            if locals()[key] is not None:
-                figure[key] = locals()[key]
+        for dict_key in ('caption', 'label', 'material'):
+            if locals()[dict_key] is not None:
+                figure[dict_key] = locals()[dict_key]
 
         if figure:
             self._append_to('figures', figure)
@@ -899,21 +905,27 @@ class LiteratureBuilder(object):
     def add_document(
         self,
         key,
+        url,
         description=None,
         fulltext=None,
         hidden=None,
         material=None,
         original_url=None,
         source=None,
-        url=None,
     ):
         """Add a document."""
         document = self._sourced_dict(source)
 
         if key:
             document['key'] = key
+        else:
+            raise TypeError("Required argument 'key' should not be 'falsey'.")
+        if url:
+            document['url'] = url
+        else:
+            raise TypeError("Required argument 'url' should not be 'falsey'.")
 
-        for key in (
+        for dict_key in (
             'description',
             'fulltext',
             'hidden',
@@ -921,8 +933,8 @@ class LiteratureBuilder(object):
             'original_url',
             'url',
         ):
-            if locals()[key] is not None:
-                document[key] = locals()[key]
+            if locals()[dict_key] is not None:
+                document[dict_key] = locals()[dict_key]
 
         if document:
             self._append_to('documents', document)

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -671,11 +671,14 @@ properties:
                         :MARC: ``8564_u``
 
                         Relative URL to the file containing the document. Its
-                        form is ``/files/bucket/key``.
+                        form is ``/files/bucket/key``. It can temprorarily be
+                        the url to download the document from, until actually
+                        downloaded.
                     format: url
                     type: string
             required:
             - key
+            - url
             type: object
         title: List of documents attached to the record
         type: array
@@ -807,6 +810,7 @@ properties:
                     type: string
             required:
             - key
+            - url
             type: object
         title: List of figures attached to the record
         type: array


### PR DESCRIPTION
The url is a field that must always be populated, either with the url
to download the document from, or with the api path to the downloaded
resource.

Signed-off-by: David Caro <david@dcaro.es>