### PR TITLE
global: make values required

### DIFF
--- a/inspire_schemas/records/elements/inspire_field.yml
+++ b/inspire_schemas/records/elements/inspire_field.yml
@@ -14,7 +14,6 @@ properties:
         - magpie
         - arxiv
         - user
-        - undefined
         type: string
     term:
         enum:
@@ -34,5 +33,7 @@ properties:
         - Theory-HEP
         - Theory-Nucl
         type: string
+required:
+- term
 title: Inspire category
 type: object

--- a/inspire_schemas/records/elements/title.yml
+++ b/inspire_schemas/records/elements/title.yml
@@ -7,4 +7,6 @@ properties:
         type: string
     title:
         type: string
+required:
+- title
 type: object

--- a/inspire_schemas/records/elements/url.yml
+++ b/inspire_schemas/records/elements/url.yml
@@ -12,5 +12,7 @@ properties:
             :MARC: ``8564_u``
         format: url
         type: string
+required:
+- value
 title: URL of related document
 type: object

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -398,6 +398,8 @@ properties:
                         :MARC: ``490__v``
                     title: Volume of the book in the series
                     type: string
+            required:
+            - title
             type: object
         type: array
     citeable:
@@ -440,6 +442,8 @@ properties:
                         :example: ``Particle Data Group``
                     title: Collaboration name
                     type: string
+            required:
+            - value
             type: object
         required:
         - value
@@ -1487,6 +1491,9 @@ properties:
                     type: string
                 title:
                     type: string
+            required:
+            - language
+            - title
             type: object
         type: array
         uniqueItems: true

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -131,7 +131,7 @@
             "term": "Math and Math Physics"
         },
         {
-            "source": "undefined",
+            "source": "magpie",
             "term": "Astrophysics"
         }
     ],

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -69,16 +69,12 @@
     ],
     "inspire_categories": [
         {
-            "source": "undefined",
+            "source": "magpie",
             "term": "Gravitation and Cosmology"
-        },
-        {
-            "source": "undefined",
-            "term": "General Physics"
         },
         {
             "source": "magpie",
-            "term": "Gravitation and Cosmology"
+            "term": "General Physics"
         }
     ],
     "inspire_classification": [

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -778,7 +778,7 @@
             "term": "Other"
         },
         {
-            "source": "undefined",
+            "source": "magpie",
             "term": "Phenomenology-HEP"
         },
         {
@@ -786,7 +786,7 @@
             "term": "Gravitation and Cosmology"
         },
         {
-            "source": "undefined",
+            "source": "magpie",
             "term": "Experiment-Nucl"
         }
     ],

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -157,10 +157,6 @@
             "term": "Computing"
         },
         {
-            "source": "undefined",
-            "term": "Theory-Nucl"
-        },
-        {
             "source": "magpie",
             "term": "Theory-Nucl"
         },


### PR DESCRIPTION
* INCOMPATIBLE Make some values required when it doesn't make sense to
have the field without them.
* Also removes ``undefined`` from ``inspire_field.source``.

Signed-off-by: Micha Moskovic <michamos@gmail.com>