### PR TITLE
builders: split journal letter in ReferenceBuilder

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -31,7 +31,7 @@ from isbn import ISBN
 
 import idutils
 
-from ..utils import normalize_author_name, split_pubnote
+from ..utils import convert_old_publication_info_to_new, normalize_author_name, split_pubnote
 
 
 # Matches any separators for author enumerations.
@@ -221,19 +221,9 @@ class ReferenceBuilder(object):
             return
 
         if self.RE_VALID_PUBNOTE.match(pubnote):
-            values = split_pubnote(pubnote)
-            keys = (
-                'journal_title',
-                'journal_volume',
-                'page_start',
-                'page_end',
-                'artid')
-            self._ensure_reference_field('publication_info', {})
-            for idx, key in enumerate(keys):
-                if values[idx]:
-                    self.obj['reference']['publication_info'][key] = (
-                        values[idx]
-                    )
+            pubnote = split_pubnote(pubnote)
+            pubnote = convert_old_publication_info_to_new([pubnote])[0]
+            self._ensure_reference_field('publication_info', pubnote)
         else:
             self.add_misc(pubnote)
 

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -372,15 +372,15 @@ def split_page_artid(page_artid):
 
 def split_pubnote(pubnote_str):
     """Split pubnote into journal information."""
-    title, volume, page_start, page_end, artid = (None, None, None, None, None)
+    pubnote = {}
     parts = pubnote_str.split(',')
 
     if len(parts) > 2:
-        title = parts[0]
-        volume = parts[1]
-        page_start, page_end, artid = split_page_artid(parts[2])
+        pubnote['journal_title'] = parts[0]
+        pubnote['journal_volume'] = parts[1]
+        pubnote['page_start'], pubnote['page_end'], pubnote['artid'] = split_page_artid(parts[2])
 
-    return title, volume, page_start, page_end, artid
+    return {key: val for (key, val) in six.iteritems(pubnote) if val is not None}
 
 
 def build_pubnote(title, volume, page_start, page_end, artid):

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -546,8 +546,8 @@ def test_set_pubnote():
             'reference': {
                 'publication_info': {
                     'artid': '362',
-                    'journal_title': 'Nucl.Phys.',
-                    'journal_volume': 'B360',
+                    'journal_title': 'Nucl.Phys.B',
+                    'journal_volume': '360',
                     'page_start': '362',
                 },
             },
@@ -593,8 +593,8 @@ def test_set_pubnote_does_not_overwrite_pubnote():
         {
             'reference': {
                 'publication_info': {
-                    'journal_title': 'Phys.Rev.',
-                    'journal_volume': 'D43',
+                    'journal_title': 'Phys.Rev.D',
+                    'journal_volume': '43',
                     'page_start': '124',
                     'page_end': '156',
                 },

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -286,7 +286,12 @@ def test_split_pubnote():
     pubnote = 'J.Testing,42,1-45'
     result = utils.split_pubnote(pubnote)
 
-    expected = 'J.Testing', '42', '1', '45', None
+    expected = {
+        'journal_title': 'J.Testing',
+        'journal_volume': '42',
+        'page_start': '1',
+        'page_end': '45',
+    }
 
     assert expected == result
 


### PR DESCRIPTION
* This calls the new `convert_old_publication_info_to_new` util  in the
ReferenceBuilder.set_pubnote method to ensure that all references
contain the letter in the `journal_title` instead of the
`journal_volume`.
* Also refactors the split_pubnote util (that is not used outside the
ReferenceBuilder) to return a `dict` instead of a `tuple`, which
simplifies things.

Signed-off-by: Micha Moskovic <michamos@gmail.com>