### PR TITLE
builders: add add_reference to literature builder

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -940,3 +940,12 @@ class LiteratureBuilder(object):
 
         if document:
             self._append_to('documents', document)
+
+    @filter_empty_parameters
+    def add_reference(self, reference):
+        """Add reference to references field.
+
+        :param reference: reference dictionary, see :class:`.ReferenceBuilder`
+        :type reference: dict
+        """
+        self._append_to('references', reference)

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -175,3 +175,17 @@ def test_literature_builder_valid_record(input_data_hep, expected_data_hep):
     builder.set_curated(curated=input_data_hep['curated'])
     assert builder.validate_record() is None
     assert builder.record == expected_data_hep
+
+
+def test_literature_and_reference_builder():
+    hep_builder = api.LiteratureBuilder()
+    hep_builder.add_document_type('article')
+    hep_builder.add_title('Work Title')
+
+    ref_builder = api.ReferenceBuilder()
+    ref_builder.add_title('Cited Work')
+    ref_builder.add_author('Smith, J.', 'author')
+
+    hep_builder.add_reference(ref_builder.obj)
+
+    assert hep_builder.validate_record() is None

--- a/tests/unit/test_literature_builder.py
+++ b/tests/unit/test_literature_builder.py
@@ -316,3 +316,22 @@ def test_repr_handles_source_present():
     assert repr(builder).startswith(
         "LiteratureBuilder(source='publisher', record={"
     )
+
+
+def test_add_reference():
+    builder = LiteratureBuilder()
+    reference = {
+        "reference": {
+            "authors": [
+                {
+                    "full_name": "Smith, J."
+                }
+            ],
+            "label": "1",
+            "publication_info": {
+                "year": 1996
+            }
+        }
+    }
+    builder.add_reference(reference)
+    assert builder.record['references'] == [reference]


### PR DESCRIPTION
Adds `add_reference` method to LiteratureBuilder.

Signed-off-by: Szymon Łopaciuk <szymon.lopaciuk@cern.ch>