### PR TITLE
builders: add journal related setters for references

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -146,6 +146,11 @@ class ReferenceBuilder(object):
         if field_name not in self.obj['reference']:
             self.obj['reference'][field_name] = value
 
+    def _set_publication_info_field(self, field_name, value):
+        """Put a value in the publication info of the reference."""
+        self._ensure_reference_field('publication_info', {})
+        self.obj['reference']['publication_info'][field_name] = value
+
     def set_label(self, label):
         self._ensure_reference_field('label', label)
 
@@ -278,3 +283,32 @@ class ReferenceBuilder(object):
     def add_collaboration(self, collaboration):
         self._ensure_reference_field('collaborations', [])
         self.obj['reference']['collaborations'].append(collaboration)
+
+    def set_journal_title(self, journal_title):
+        """Add journal title."""
+        self._set_publication_info_field('journal_title', journal_title)
+
+    def set_journal_issue(self, journal_issue):
+        """Add journal issue."""
+        self._set_publication_info_field('journal_issue', journal_issue)
+
+    def set_journal_volume(self, journal_volume):
+        """Add journal volume."""
+        self._set_publication_info_field('journal_volume', journal_volume)
+
+    def set_page_artid(self, page_start, page_end, artid):
+        """Add artid, start, end pages to publication info of a reference.
+
+        Args:
+            page_start(Optional[string]): value for the field page_start
+            page_end(Optional[string]): value for the field page_end
+            artid(Optional[string]): value for the field artid
+        """
+        self._ensure_reference_field('publication_info', {})
+        publication_info = self.obj['reference']['publication_info']
+        if page_start:
+            publication_info['page_start'] = page_start
+        if page_end:
+            publication_info['page_end'] = page_end
+        if artid:
+            publication_info['artid'] = artid

--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -296,14 +296,20 @@ class ReferenceBuilder(object):
         """Add journal volume."""
         self._set_publication_info_field('journal_volume', journal_volume)
 
-    def set_page_artid(self, page_start, page_end, artid):
+    def set_page_artid(self, page_start=None, page_end=None, artid=None):
         """Add artid, start, end pages to publication info of a reference.
 
         Args:
             page_start(Optional[string]): value for the field page_start
             page_end(Optional[string]): value for the field page_end
             artid(Optional[string]): value for the field artid
+
+        Raises:
+            ValueError: when no start_page given for an end_page
         """
+        if page_end and not page_start:
+            raise ValueError('End_page provided without start_page')
+
         self._ensure_reference_field('publication_info', {})
         publication_info = self.obj['reference']['publication_info']
         if page_start:

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -856,3 +856,120 @@ def test_add_collaboration():
 
     assert validate(result, subschema) is None
     assert expected == result
+
+
+def test_set_journal_title():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_journal_title('Phys. Rev. D')
+
+    expected = [
+        {
+            'reference': {
+                'publication_info': {
+                    'journal_title': 'Phys. Rev. D'
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_set_journal_issue():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_journal_issue('12')
+
+    expected = [
+        {
+            'reference': {
+                'publication_info': {
+                    'journal_issue': '12'
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_set_journal_volume():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_journal_volume('2016')
+
+    expected = [
+        {
+            'reference': {
+                'publication_info': {
+                    'journal_volume': '2016'
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_set_page_artid():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_page_artid('12', '13', '014568')
+
+    expected = [
+        {
+            'reference': {
+                'publication_info': {
+                    'page_start': '12',
+                    'page_end': '13',
+                    'artid': '014568',
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_set_page_artid_none():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_page_artid(None, None, '014568')
+
+    expected = [
+        {
+            'reference': {
+                'publication_info': {
+                    'artid': '014568',
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result


### PR DESCRIPTION
To `ReferenceBuilder` add functionality to set:

- journal title, issue and volume
- start and end page and/or article id

Currently it's possible to do a workaround using `build_pubnote` and `set_pubnote`, however it's not possible to do that for `journal_issue` field. This adds above facilities to add the fields directly.