### PR TITLE
fix UnicodeEncodeError when writing to the changelog

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@
 from __future__ import print_function
 
 import os
+from io import open
 
 from autosemver.packaging import get_changelog, get_current_version
 from jsonschema2rst.parser_runner import run_parser


### PR DESCRIPTION
Replaced open with codecs.open to write unicode to the `CHANGELOG.txt` file as UTF-8.