### PR TITLE
elements/id: require ORCIDs to be valid

### DIFF
--- a/inspire_schemas/records/elements/id.yml
+++ b/inspire_schemas/records/elements/id.yml
@@ -67,6 +67,7 @@ anyOf:
         value:
             description: |-
                 :example: ``0000-0012-1234-5647``
+            format: orcid
             pattern: ^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$
             type: string
     required:

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -30,6 +30,7 @@ import os
 import re
 
 import six
+from idutils import is_orcid
 from inspire_utils.date import PartialDate
 from jsonschema import validate as jsonschema_validate
 from jsonschema import RefResolver, draft4_format_checker
@@ -511,6 +512,7 @@ def load_schema(schema_name, resolved=False):
 
 inspire_format_checker = draft4_format_checker
 inspire_format_checker.checks('date', raises=ValueError)(PartialDate.loads)
+inspire_format_checker.checks('orcid')(is_orcid)
 
 
 def validate(data, schema=None):

--- a/scripts/generate_example_records.js
+++ b/scripts/generate_example_records.js
@@ -10,6 +10,21 @@ jsf.format('date', function(gen, schema){
     var date = moment.unix(timestamp);
     return date.format('YYYY-MM-DD');
 });
+jsf.format('orcid', function(gen, schema){
+    var almost_orcid = gen.randexp(/0000-0002-\d{4}-\d{3}/)
+    var input = almost_orcid.replace(/-/g,'')
+    var r = 0
+    for (i = 0; i < input.length; i++) {
+        r = (r + parseInt(input.split('')[i]))*2
+    }
+    var ck = (12 - r % 11) % 11
+    if (ck == 10) {
+        ck = 'X'
+    } else {
+        ck = String(ck)
+    }
+    return almost_orcid + ck
+});
 jsf.format('url', function(gen, schema){ return gen.randexp('^http://1.*$');});
 jsf.format('.+, .+', function(gen, schema){ return gen.randexp('^.+, .+$');});
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -117,3 +117,28 @@ def test_validate_raises_on_invalid_date_time():
 
     with pytest.raises(ValidationError):
         utils.validate(data, schema)
+
+
+def test_validate_accepts_valid_orcid():
+    data = '0000-0002-3151-4077'
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'orcid',
+    }
+
+    utils.validate(data, schema)
+
+
+def test_validate_raises_on_invalid_orcid():
+    data = '0000-0012-1234-5647'
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'orcid',
+    }
+
+    with pytest.raises(ValidationError):
+        utils.validate(data, schema)


### PR DESCRIPTION
* As suggested by @tsgit, this adds a new `orcid` `format` that uses
`idutils.is_orcid` for validation (as well as the corresponding example
generator) to ensure that valid records can contain only valid ORCIDs.

Signed-off-by: Micha Moskovic <michamos@gmail.com>