### PR TITLE
hep: add legacy_curated flag to references

### DIFF
--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -1334,6 +1334,14 @@ properties:
             properties:
                 curated_relation:
                     type: boolean
+                legacy_curated:
+                    description: |-
+                        :MARC: ``999C59:CURATOR`` corresponds to ``True``
+
+                        Whether the reference has been modified be a curator to
+                        correct errors in reference extraction from the
+                        document.
+                    type: boolean
                 raw_refs:
                     description: |-
                         :MARC: ``999C5x``

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -1065,6 +1065,7 @@
     "references": [
         {
             "curated_relation": true,
+            "legacy_curated": false,
             "raw_refs": [
                 {
                     "schema": "ex",


### PR DESCRIPTION
* This allows to preserve the information of `9:CURATOR` and correctly
send it back to legacy.

Signed-off-by: Micha Moskovic <michamos@gmail.com>