### PR TITLE
builders: detect APS new-style arXiv ID with class

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -44,7 +44,7 @@ RE_INITIALS_ONLY = re.compile(r'^\s*-?[A-Z]((\.|\s)\s*-?[A-Z])*\.?\s*$',
 # Matches new style arXiv ID, with an old-style class specification
 # (Malformed, but appears in APS records)
 RE_ARXIV_POST_2007_CLASS = re.compile(
-    "(arxiv:)(?:[a-z\-]+)(?:\.[a-z]{2})?/(\d{4})\.(\d{4,5})(v\d+)?$",
+    "(arxiv:)?(?:[a-z\-]+)(?:\.[a-z]{2})?/(\d{4})\.(\d{4,5})(v\d+)?$",
     flags=re.I
 )
 

--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -41,6 +41,12 @@ RE_SPLIT_AUTH = re.compile(r',?\s+and\s|,?\s*&|,|et al\.?|\(?eds?\.\)?',
 # Matches any stream of initials (A. B C D. -E F).
 RE_INITIALS_ONLY = re.compile(r'^\s*-?[A-Z]((\.|\s)\s*-?[A-Z])*\.?\s*$',
                               re.U)
+# Matches new style arXiv ID, with an old-style class specification
+# (Malformed, but appears in APS records)
+RE_ARXIV_POST_2007_CLASS = re.compile(
+    "(arxiv:)(?:[a-z\-]+)(?:\.[a-z]{2})?/(\d{4})\.(\d{4,5})(v\d+)?$",
+    flags=re.I
+)
 
 
 def _split_refextract_authors_str(authors_str):
@@ -97,7 +103,8 @@ def _is_arxiv(obj):
     arxiv_test = obj.split()
     if not arxiv_test:
         return False
-    return idutils.is_arxiv(arxiv_test[0])
+    return idutils.is_arxiv(arxiv_test[0]) \
+        or RE_ARXIV_POST_2007_CLASS.match(arxiv_test[0])
 
 
 def _normalize_arxiv(obj):
@@ -114,7 +121,7 @@ def _normalize_arxiv(obj):
     if m:
         return ''.join(m.group(2, 4, 5))
 
-    m = idutils.is_arxiv_post_2007(obj)
+    m = idutils.is_arxiv_post_2007(obj) or RE_ARXIV_POST_2007_CLASS.match(obj)
     if m:
         return '.'.join(m.group(2, 3))
 

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -39,6 +39,10 @@ def test_is_arxiv_old_identifier():
     assert _is_arxiv('hep-th/0603001')
 
 
+def test_is_arxiv_new_with_class():
+    assert _is_arxiv('arXiv:hep-th/1601.07616')
+
+
 def test_normalize_arxiv_handles_new_identifiers_without_prefix_or_version():
     expected = '1501.00001'
     result = _normalize_arxiv('1501.00001')
@@ -98,6 +102,34 @@ def test_normalize_arxiv_handles_old_identifiers_with_prefix_and_version():
 def test_normalize_arxiv_handles_solv_int():
     expected = 'solv-int/9611008'
     result = _normalize_arxiv('solv-int/9611008')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_class_and_wo_version():
+    expected = '1501.00001'
+    result = _normalize_arxiv('arXiv:hep-th/1501.00001')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_class_and_version():
+    expected = '1501.00001'
+    result = _normalize_arxiv('arXiv:hep-th/1501.00001v1')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_cls_prefix_and_wo_ver():
+    expected = '1501.00001'
+    result = _normalize_arxiv('arXiv:hep-th.GT/1501.00001')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_cls_prefix_and_ver():
+    expected = '1501.00001'
+    result = _normalize_arxiv('arXiv:hep-th.GT/1501.00001v1')
 
     assert expected == result
 

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -43,6 +43,10 @@ def test_is_arxiv_new_with_class():
     assert _is_arxiv('arXiv:hep-th/1601.07616')
 
 
+def test_is_arxiv_new_with_class_wo_prefix():
+    assert _is_arxiv('hep-th/1601.07616')
+
+
 def test_normalize_arxiv_handles_new_identifiers_without_prefix_or_version():
     expected = '1501.00001'
     result = _normalize_arxiv('1501.00001')
@@ -123,6 +127,13 @@ def test_normalize_arxiv_handles_new_identifiers_with_class_and_version():
 def test_normalize_arxiv_handles_new_identifiers_with_cls_prefix_and_wo_ver():
     expected = '1501.00001'
     result = _normalize_arxiv('arXiv:hep-th.GT/1501.00001')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_cls_and_wo_prefix_ver():
+    expected = '1501.00001'
+    result = _normalize_arxiv('hep-th.GT/1501.00001')
 
     assert expected == result
 


### PR DESCRIPTION
Detect and normalise arXiv IDs of the form `arXiv:hep-th/1601.07616`, which are technically invalid, but appear in APS records.