### PR TITLE
builders: add a public note for submitted records

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -485,6 +485,15 @@ class LiteratureBuilder(object):
         :param parent_record: reference for the parent record
         :type parent_record: string
         """
+
+        # If only journal title is present, and no other fields, assume the
+        # paper was submitted, but not yet published
+        if journal_title and all(
+                not field for field in (cnum, artid, journal_issue,
+                                        journal_volume, page_start, page_end)):
+            self.add_public_note('Submitted to {}'.format(journal_title))
+            return
+
         publication_item = {}
         for key in ('cnum', 'artid', 'page_end', 'page_start',
                     'journal_issue', 'journal_title',

--- a/tests/unit/test_literature_builder.py
+++ b/tests/unit/test_literature_builder.py
@@ -335,3 +335,22 @@ def test_add_reference():
     }
     builder.add_reference(reference)
     assert builder.record['references'] == [reference]
+
+
+def test_publication_info_public_note():
+    schema = load_schema('hep')
+    subschema = schema['properties']['public_notes']
+    builder = LiteratureBuilder(source="APS")
+    builder.add_publication_info(journal_title="Phys. Rev. B")
+
+    expected = [
+        {
+            'source': 'APS',
+            'value': 'Submitted to Phys. Rev. B',
+        }
+    ]
+    result = builder.record['public_notes']
+
+    assert validate(result, subschema) is None
+    assert expected == result
+    assert 'publication_info' not in builder.record


### PR DESCRIPTION
Add a "Submitted to..." public note for records which only have `journal_title` specified in `add_publication_info`.