### PR TITLE
global: use uri/uri-reference formats, not url

### DIFF
--- a/inspire_schemas/records/authors.yml
+++ b/inspire_schemas/records/authors.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         items:

--- a/inspire_schemas/records/conferences.yml
+++ b/inspire_schemas/records/conferences.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         items:

--- a/inspire_schemas/records/elements/json_reference.yml
+++ b/inspire_schemas/records/elements/json_reference.yml
@@ -4,7 +4,7 @@ properties:
     $ref:
         description: |-
             URL to the referenced resource
-        format: url
+        format: uri
         type: string
 required:
 - $ref

--- a/inspire_schemas/records/elements/url.yml
+++ b/inspire_schemas/records/elements/url.yml
@@ -10,7 +10,7 @@ properties:
     value:
         description: |-
             :MARC: ``8564_u``
-        format: url
+        format: uri
         type: string
 title: URL of related document
 type: object

--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -5,7 +5,7 @@ description: |-
     value of :ref:`experiments.json#/properties/project_type`.
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         items:

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         description: |-
@@ -489,7 +489,7 @@ properties:
                     title: Copyright notice
                     type: string
                 url:
-                    format: url
+                    format: uri
                     title: Copyright notice URL
                     type: string
                 year:
@@ -664,7 +664,7 @@ properties:
                 material:
                     $ref: elements/material.json
                 original_url:
-                    format: url
+                    format: uri
                     title: Original URL of the document
                     type: string
                 source:
@@ -677,7 +677,7 @@ properties:
                         form is ``/files/bucket/key``. It can temprorarily be
                         the url to download the document from, until actually
                         downloaded.
-                    format: url
+                    format: uri-reference
                     type: string
             required:
             - key
@@ -809,7 +809,7 @@ properties:
 
                         Relative URL to the file containing the figure. Its
                         form is ``/files/bucket/key``.
-                    format: url
+                    format: uri-reference
                     type: string
             required:
             - key
@@ -1047,7 +1047,7 @@ properties:
 
                         URL where the full license statement may be found, if
                         only a short name is provided in ``license``.
-                    format: url
+                    format: uri
                     title: URL of the license
                     type: string
             type: object

--- a/inspire_schemas/records/institutions.yml
+++ b/inspire_schemas/records/institutions.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     ICN:
         description: |-

--- a/inspire_schemas/records/jobs.yml
+++ b/inspire_schemas/records/jobs.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         items:

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $schema:
-        format: url
+        format: uri
         type: string
     _collections:
         items:
@@ -212,7 +212,7 @@ properties:
 
                     URL where the full license statement may be found, if
                     only a short name is provided in ``license``.
-                format: url
+                format: uri
                 title: URL of the license
                 type: string
         type: object

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -28,7 +28,9 @@ import copy
 import json
 import os
 import re
+from functools import partial
 
+import rfc3987
 import six
 from inspire_utils.date import PartialDate
 from jsonschema import validate as jsonschema_validate
@@ -509,6 +511,9 @@ def load_schema(schema_name, resolved=False):
 
 inspire_format_checker = draft4_format_checker
 inspire_format_checker.checks('date', raises=ValueError)(PartialDate.loads)
+inspire_format_checker.checks('uri-reference', raises=ValueError)(
+    partial(rfc3987.parse, rule='URI_reference')
+)
 
 
 def validate(data, schema=None):

--- a/scripts/generate_example_records.js
+++ b/scripts/generate_example_records.js
@@ -10,7 +10,7 @@ jsf.format('date', function(gen, schema){
     var date = moment.unix(timestamp);
     return date.format('YYYY-MM-DD');
 });
-jsf.format('url', function(gen, schema){ return gen.randexp('^http://1.*$');});
+jsf.format('uri-reference', function(gen, schema){ return gen.randexp('^(https?://)?[\\w.]+/[\\w]+[\\w/]+$');});
 jsf.format('.+, .+', function(gen, schema){ return gen.randexp('^.+, .+$');});
 
 function resolve_schema(unresolved_schema, base_path) {

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ def do_setup():
             'inspire-utils',
             'isodate',
             'pyyaml',
+            'rfc3987',
             'six',
             'unidecode',
         ],

--- a/tests/integration/fixtures/authors_example.json
+++ b/tests/integration/fixtures/authors_example.json
@@ -101,7 +101,7 @@
             ],
             "name": "ea voluptate esse commodo",
             "record": {
-                "$ref": "http://1X!1}>p\""
+                "$ref": "http://example.com"
             }
         },
         {
@@ -123,7 +123,7 @@
             ],
             "name": "minim",
             "record": {
-                "$ref": "http://1.e2T.9)>"
+                "$ref": "http://1.e2T.9"
             }
         }
     ],
@@ -136,16 +136,16 @@
     "birth_date": "1991-10-21",
     "conferences": [
         {
-            "$ref": "http://1]| cswr%"
+            "$ref": "http://1cswr"
         },
         {
             "$ref": "http://1iS3Rnw"
         },
         {
-            "$ref": "http://1F%|'$!;Q{"
+            "$ref": "http://1FQ"
         },
         {
-            "$ref": "http://1jpRGM^a"
+            "$ref": "http://1jpRGMa"
         }
     ],
     "control_number": 51954716,
@@ -153,16 +153,16 @@
     "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://1qI7O!"
+            "$ref": "http://1qI7O"
         },
         {
             "$ref": "http://1Dh"
         },
         {
-            "$ref": "http://1w7a<p"
+            "$ref": "http://1w7ap"
         },
         {
-            "$ref": "http://1m4iwA7GCY|"
+            "$ref": "http://1m4iwA7GCY"
         },
         {
             "$ref": "http://12mRGx6"
@@ -180,7 +180,7 @@
             "end_year": -19766966,
             "name": "amet dolore in voluptate",
             "record": {
-                "$ref": "http://1;zWS[a"
+                "$ref": "http://1zWSa"
             },
             "start_year": -4478687
         },
@@ -190,7 +190,7 @@
             "end_year": -42706407,
             "name": "anim",
             "record": {
-                "$ref": "http://1Ql!C"
+                "$ref": "http://1QlC"
             },
             "start_year": 65829453
         },
@@ -220,7 +220,7 @@
             "end_year": 39168632,
             "name": "sed et id sit",
             "record": {
-                "$ref": "http://1>=6r>I"
+                "$ref": "http://16rI"
             },
             "start_year": 24393456
         }
@@ -280,7 +280,7 @@
         "Duis voluptate eu"
     ],
     "new_record": {
-        "$ref": "http://1/^}vZW'"
+        "$ref": "http://1/vZW'"
     },
     "other_names": [
         "ut adipisicing quis proident",
@@ -302,7 +302,7 @@
                 "curated_relation": false,
                 "name": "quis",
                 "record": {
-                    "$ref": "http://1p>w|)"
+                    "$ref": "http://1pw)"
                 }
             },
             "old_emails": [
@@ -340,7 +340,7 @@
         }
     ],
     "self": {
-        "$ref": "http://1~\""
+        "$ref": "http://1"
     },
     "source": [
         {
@@ -361,19 +361,19 @@
     "urls": [
         {
             "description": "et ipsum",
-            "value": "http://1("
+            "value": "http://1"
         },
         {
             "description": "id s",
-            "value": "http://1C<"
+            "value": "http://1C"
         },
         {
             "description": "commodo non ",
-            "value": "http://17c>x@;zb["
+            "value": "http://17cx@zb"
         },
         {
             "description": "adipisicing labore ipsum commodo Duis",
-            "value": "http://1~,w?"
+            "value": "http://1w"
         }
     ]
 }

--- a/tests/integration/fixtures/conferences_example.json
+++ b/tests/integration/fixtures/conferences_example.json
@@ -90,13 +90,13 @@
             "$ref": "http://1"
         },
         {
-            "$ref": "http://1,~DqZ?"
+            "$ref": "http://1DqZ"
         },
         {
-            "$ref": "http://1:Q"
+            "$ref": "http://1Q"
         },
         {
-            "$ref": "http://1Uo%/k"
+            "$ref": "http://1Uok"
         }
     ],
     "external_system_identifiers": [
@@ -159,7 +159,7 @@
         }
     ],
     "self": {
-        "$ref": "http://1=WXIwz*5"
+        "$ref": "http://1WXIwz5"
     },
     "series": [
         {
@@ -213,15 +213,15 @@
         },
         {
             "description": "fugiat minim dolor Duis",
-            "value": "http://1IAaWsk="
+            "value": "http://1IAaWsk"
         },
         {
             "description": "sint occaecat proident id adipisicing",
-            "value": "http://1^p-~Bi0"
+            "value": "http://1pBi0"
         },
         {
             "description": "sit elit labore",
-            "value": "http://1S&UAB"
+            "value": "http://1SUAB"
         }
     ]
 }

--- a/tests/integration/fixtures/experiments_example.json
+++ b/tests/integration/fixtures/experiments_example.json
@@ -20,14 +20,14 @@
     "accelerator": {
         "curated_relation": true,
         "record": {
-            "$ref": "http://1PK7LC\\,L6$"
+            "$ref": "http://1PK7LCL6"
         },
         "value": "occaecat enim veniam incididunt fugiat"
     },
     "collaboration": {
         "curated_relation": false,
         "record": {
-            "$ref": "http://1h=fzx^="
+            "$ref": "http://1hfzx"
         },
         "subgroup_names": [
             "mollit Lorem quis",
@@ -46,10 +46,10 @@
     "deleted": true,
     "deleted_records": [
         {
-            "$ref": "http://1Ou$(?Pqa1/"
+            "$ref": "http://1OuPqa1/"
         },
         {
-            "$ref": "http://1Vf'fg"
+            "$ref": "http://1Vffg"
         }
     ],
     "description": "consequat dolore in quis",
@@ -92,7 +92,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1.K_ #-/"
+                "$ref": "http://1.K-/"
             },
             "value": ""
         },
@@ -106,7 +106,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1{VG-Aj@Yv"
+                "$ref": "http://1VG-AjYv"
             },
             "value": "laboris in"
         },
@@ -120,7 +120,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1\\"
+                "$ref": "http://1"
             },
             "value": "dolore"
         }
@@ -151,23 +151,23 @@
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1E=y}"
+                "$ref": "http://1Ey"
             },
             "relation": "commented",
             "relation_freetext": "mollit"
         }
     ],
     "self": {
-        "$ref": "http://1rk1AKe[& m"
+        "$ref": "http://1rk1AKem"
     },
     "urls": [
         {
             "description": "ut nisi",
-            "value": "http://1/M|"
+            "value": "http://1/M"
         },
         {
             "description": "deserunt",
-            "value": "http://1ybsM8alB[:"
+            "value": "http://1ybsM8alB"
         }
     ]
 }

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -108,7 +108,7 @@
             "institution": "culpa esse in",
             "legacy_name": "aliquip sint nisi",
             "record": {
-                "$ref": "http://1+Q\\\\"
+                "$ref": "http://1Q"
             }
         },
         {
@@ -118,7 +118,7 @@
             "institution": "nostrud enim esse",
             "legacy_name": "laboris Ut",
             "record": {
-                "$ref": "http://1}P9qA"
+                "$ref": "http://1P9qA"
             }
         },
         {
@@ -128,7 +128,7 @@
             "institution": "occaecat",
             "legacy_name": "enim cupidatat",
             "record": {
-                "$ref": "http://1B-EQu,c"
+                "$ref": "http://1B-EQuc"
             }
         },
         {
@@ -148,7 +148,7 @@
             "institution": "Lorem sint",
             "legacy_name": "ullamco laboris ex",
             "record": {
-                "$ref": "http://1_!"
+                "$ref": "http://1_"
             }
         }
     ],
@@ -250,7 +250,7 @@
                 }
             ],
             "record": {
-                "$ref": "http://1& ~D!R;h$."
+                "$ref": "http://1DRh."
             },
             "signature_block": "proident ut commodo irure nostrud",
             "uuid": "5c2e01fd-6924-ce9f-10d3-0c44c07e55f4"
@@ -337,28 +337,28 @@
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1\\:~B/)43F["
+                        "$ref": "http://1B/43F"
                     },
                     "value": "ipsum elit"
                 },
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1?MVG(cA3"
+                        "$ref": "http://1MVGcA3"
                     },
                     "value": "sunt sint nulla"
                 },
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1qwr8()BD>w"
+                        "$ref": "http://1qwr8BDw"
                     },
                     "value": "in"
                 },
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://17:0@PHP"
+                        "$ref": "http://170PHP"
                     },
                     "value": "in fugiat ut"
                 }
@@ -433,21 +433,21 @@
                 {
                     "curated_relation": false,
                     "record": {
-                        "$ref": "http://1m="
+                        "$ref": "http://1m"
                     },
                     "value": "aute voluptate sed laboris"
                 },
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1p`8L"
+                        "$ref": "http://1p8L"
                     },
                     "value": "dolor in d"
                 },
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://1g7Zz[';k"
+                        "$ref": "http://1g7Zzk"
                     },
                     "value": "sit nulla aliquip labor"
                 }
@@ -497,7 +497,7 @@
                 }
             ],
             "record": {
-                "$ref": "http://1v60L!2M6-O"
+                "$ref": "http://1v60L2M6-O"
             },
             "signature_block": "est",
             "uuid": "ae5afd4c-c5c2-df10-298a-6ea187577de8"
@@ -507,7 +507,7 @@
                 {
                     "curated_relation": true,
                     "record": {
-                        "$ref": "http://118^"
+                        "$ref": "http://118"
                     },
                     "value": "proident eiusmod"
                 }
@@ -564,7 +564,7 @@
                 }
             ],
             "record": {
-                "$ref": "http://1:q#ov?/"
+                "$ref": "http://1qov/"
             },
             "signature_block": "do temp",
             "uuid": "adfd51c0-e7da-9016-9919-b9843ab279e3"
@@ -584,7 +584,7 @@
     "collaborations": [
         {
             "record": {
-                "$ref": "http://1o,"
+                "$ref": "http://1o"
             },
             "value": "cupidatat"
         },
@@ -596,7 +596,7 @@
         },
         {
             "record": {
-                "$ref": "http://12,`!tNn4e"
+                "$ref": "http://12tNn4e"
             },
             "value": "ea Ut"
         }
@@ -607,21 +607,21 @@
             "holder": "dolore incididunt r",
             "material": "preprint",
             "statement": "consequat eu",
-            "url": "http://1b'h)Z",
+            "url": "http://1bhZ",
             "year": 1534
         },
         {
             "holder": "ullamco",
             "material": "translation",
             "statement": "cupidatat quis amet incididunt pariatur",
-            "url": "http://1\\",
+            "url": "http://1",
             "year": 1289
         },
         {
             "holder": "laborum esse Ut reprehenderit cupidatat",
             "material": "preprint",
             "statement": "incididunt",
-            "url": "http://18KTrig*",
+            "url": "http://18KTrig",
             "year": 1574
         }
     ],
@@ -640,7 +640,7 @@
             "$ref": "http://1X"
         },
         {
-            "$ref": "http://1w~\\i<-"
+            "$ref": "http://1wi-"
         }
     ],
     "document_type": [
@@ -654,9 +654,9 @@
             "hidden": true,
             "key": "aliqua labore amet Ut pariatur",
             "material": "addendum",
-            "original_url": "http://13j~ottN",
+            "original_url": "http://13jottN",
             "source": "es",
-            "url": "http://132X(S?@\\I<"
+            "url": "http://132XSI"
         },
         {
             "description": "nisi",
@@ -664,9 +664,9 @@
             "hidden": true,
             "key": "exercitation dolore culpa do elit",
             "material": "reprint",
-            "original_url": "http://1Tc_; =",
+            "original_url": "http://1Tc",
             "source": "in ipsum ullamco",
-            "url": "http://1Tv_\\ ;@be"
+            "url": "http://1Tvbe"
         },
         {
             "description": "magna in sunt Ut",
@@ -674,9 +674,9 @@
             "hidden": true,
             "key": "deserunt dolore ullamco non sed",
             "material": "editorial note",
-            "original_url": "http://1mLo\"IM9S=",
+            "original_url": "http://1mLoIM9S",
             "source": "in adipisicing",
-            "url": "http://1]R0#,%2e=u"
+            "url": "http://1R02eu"
         }
     ],
     "dois": [
@@ -733,7 +733,7 @@
             "label": "ad eiusmod est",
             "material": "erratum",
             "source": "deserunt eu id",
-            "url": "http://1(v2ETQ"
+            "url": "http://1v2ETQ"
         },
         {
             "caption": "in",
@@ -857,7 +857,7 @@
             "imposing": "eiusmod cupidatat aliquip laborum laboris",
             "license": "in",
             "material": "erratum",
-            "url": "http://1* JgF-wFtS"
+            "url": "http://1JgF-wFtS"
         },
         {
             "imposing": "do",
@@ -867,7 +867,7 @@
         }
     ],
     "new_record": {
-        "$ref": "http://179.\"K'p)mg"
+        "$ref": "http://179.Kpmg"
     },
     "number_of_pages": 30699287,
     "persistent_identifiers": [
@@ -901,13 +901,13 @@
             "cnum": "C64-30-40",
             "conf_acronym": "sit id proident non",
             "conference_record": {
-                "$ref": "http://1a%"
+                "$ref": "http://1a"
             },
             "curated_relation": true,
             "hidden": true,
             "journal_issue": "eiusmod consectetur velit labore",
             "journal_record": {
-                "$ref": "http://1jLUvM{S"
+                "$ref": "http://1jLUvMS"
             },
             "journal_title": "consequat",
             "journal_volume": "irure Ut",
@@ -916,7 +916,7 @@
             "page_start": "incididunt sit consectetur sunt Lore",
             "parent_isbn": "2321061939",
             "parent_record": {
-                "$ref": "http://1(7.|<MB>"
+                "$ref": "http://17.MB"
             },
             "parent_report_number": "eiusmod",
             "pubinfo_freetext": "nostrud",
@@ -927,7 +927,7 @@
             "cnum": "C78-99-06.93726",
             "conf_acronym": "esse",
             "conference_record": {
-                "$ref": "http://1sqv+cM"
+                "$ref": "http://1sqvcM"
             },
             "curated_relation": true,
             "hidden": true,
@@ -942,7 +942,7 @@
             "page_start": "veniam",
             "parent_isbn": "92348907",
             "parent_record": {
-                "$ref": "http://1V%,'UX"
+                "$ref": "http://1VUX"
             },
             "parent_report_number": "esse dolore",
             "pubinfo_freetext": "reprehende",
@@ -953,7 +953,7 @@
             "cnum": "C77-94-88",
             "conf_acronym": "voluptate est qui in",
             "conference_record": {
-                "$ref": "http://1|"
+                "$ref": "http://1"
             },
             "curated_relation": false,
             "hidden": false,
@@ -994,7 +994,7 @@
             "page_start": "cillum sit culpa labore",
             "parent_isbn": "89142",
             "parent_record": {
-                "$ref": "http://1siN9H^ x"
+                "$ref": "http://1siN9Hx"
             },
             "parent_report_number": "adipisicing",
             "pubinfo_freetext": "Lorem Duis Excepteur",
@@ -1005,13 +1005,13 @@
             "cnum": "C71-40-75.5773136826",
             "conf_acronym": "id nulla sit reprehenderit",
             "conference_record": {
-                "$ref": "http://1:5xf"
+                "$ref": "http://15xf"
             },
             "curated_relation": false,
             "hidden": true,
             "journal_issue": "do",
             "journal_record": {
-                "$ref": "http://1CD<Lqvz/3b"
+                "$ref": "http://1CDLqvz/3b"
             },
             "journal_title": "consectetur ",
             "journal_volume": "pariatur veniam nisi id in",
@@ -1035,14 +1035,14 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1KF[=9"
+                "$ref": "http://1KF9"
             },
             "value": "id anim tempor aliqua"
         },
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1I4O}a=Dt["
+                "$ref": "http://1I4ODt"
             },
             "value": "es"
         },
@@ -1188,7 +1188,7 @@
                     },
                     {
                         "description": "ea in ut dolore",
-                        "value": "http://1+CX-?M+"
+                        "value": "http://1CX-M"
                     }
                 ]
             }
@@ -1198,7 +1198,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1) #(9%#"
+                "$ref": "http://19"
             },
             "relation": "predecessor",
             "relation_freetext": "aute incididunt"
@@ -1206,7 +1206,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1j'<]"
+                "$ref": "http://1j"
             },
             "relation": "commented",
             "relation_freetext": "Lorem"
@@ -1214,7 +1214,7 @@
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1u,YUG"
+                "$ref": "http://1uYUG"
             },
             "relation": "parent",
             "relation_freetext": "tempor consectetur sunt"
@@ -1222,7 +1222,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1+qU*AO/Er0"
+                "$ref": "http://1qUAO/Er0"
             },
             "relation": "predecessor",
             "relation_freetext": "fugiat esse no"
@@ -1230,7 +1230,7 @@
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1{t"
+                "$ref": "http://1t"
             },
             "relation": "parent",
             "relation_freetext": "in est in do"
@@ -1328,7 +1328,7 @@
         },
         {
             "description": "mollit ad",
-            "value": "http://1L-,O]"
+            "value": "http://1L-O"
         }
     ],
     "withdrawn": true

--- a/tests/integration/fixtures/institutions_example.json
+++ b/tests/integration/fixtures/institutions_example.json
@@ -111,7 +111,7 @@
             "$ref": "http://1k'lNb_e"
         },
         {
-            "$ref": "http://1?\\i"
+            "$ref": "http://1i"
         },
         {
             "$ref": "http://1O"
@@ -215,7 +215,7 @@
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1v3[%l"
+                "$ref": "http://1v3l"
             },
             "relation": "commented",
             "relation_freetext": "occaecat pariatur dolor laborum"
@@ -223,7 +223,7 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1[M"
+                "$ref": "http://1M"
             },
             "relation": "commented",
             "relation_freetext": "esse ullamco"
@@ -239,19 +239,19 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1GU}312,j"
+                "$ref": "http://1GU312j"
             },
             "relation": "commented",
             "relation_freetext": "sed pariatur ut et ullamco"
         }
     ],
     "self": {
-        "$ref": "http://1d.P{sX%`"
+        "$ref": "http://1d.PsX"
     },
     "urls": [
         {
             "description": "voluptate consequat Duis non minim",
-            "value": "http://1Q2P-)Y;IH8"
+            "value": "http://1Q2P-YIH8"
         },
         {
             "description": "aliquip incididunt",

--- a/tests/integration/fixtures/jobs_example.json
+++ b/tests/integration/fixtures/jobs_example.json
@@ -109,16 +109,16 @@
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1,d'js1E~ u"
+            "$ref": "http://1djs1Eu"
         },
         {
-            "$ref": "http://1fY\\u\\Sz8"
+            "$ref": "http://1fYuSz8"
         },
         {
-            "$ref": "http://1_bybs?yj"
+            "$ref": "http://1_bybsyj"
         },
         {
-            "$ref": "http://1jDD~"
+            "$ref": "http://1jDD"
         }
     ],
     "description": "sint conseq",
@@ -127,21 +127,21 @@
             "curated_relation": true,
             "name": "ut fugiat commodo tempor",
             "record": {
-                "$ref": "http://19)m$>`B"
+                "$ref": "http://19mB"
             }
         },
         {
             "curated_relation": false,
             "name": "do minim aliqua veniam Duis",
             "record": {
-                "$ref": "http://1kYq8%>y"
+                "$ref": "http://1kYq8y"
             }
         },
         {
             "curated_relation": false,
             "name": "cillum magna id",
             "record": {
-                "$ref": "http://1C2\\c:"
+                "$ref": "http://1C2"
             }
         }
     ],
@@ -178,41 +178,41 @@
             "curated_relation": true,
             "name": "culpa",
             "record": {
-                "$ref": "http://1)~pullY"
+                "$ref": "http://1pullY"
             }
         },
         {
             "curated_relation": true,
             "name": "est dolor velit",
             "record": {
-                "$ref": "http://1 :Lq5Bht"
+                "$ref": "http://1Lq5Bht"
             }
         },
         {
             "curated_relation": true,
             "name": "consequat nos",
             "record": {
-                "$ref": "http://1Ik(>"
+                "$ref": "http://1Ik"
             }
         },
         {
             "curated_relation": true,
             "name": "velit",
             "record": {
-                "$ref": "http://1&w"
+                "$ref": "http://1w"
             }
         },
         {
             "curated_relation": false,
             "name": "Excepteur minim",
             "record": {
-                "$ref": "http://15!){(1"
+                "$ref": "http://151"
             }
         }
     ],
     "legacy_creation_date": "1971-02-11",
     "new_record": {
-        "$ref": "http://13l}"
+        "$ref": "http://13l"
     },
     "position": "sit nulla",
     "public_notes": [
@@ -251,12 +251,12 @@
         "Middle East"
     ],
     "self": {
-        "$ref": "http://1p?v<7U(7W"
+        "$ref": "http://1pv7U7W"
     },
     "urls": [
         {
             "description": "amet labori",
-            "value": "http://1z.\".%-0.["
+            "value": "http://1z.-0"
         }
     ]
 }

--- a/tests/integration/fixtures/journals_example.json
+++ b/tests/integration/fixtures/journals_example.json
@@ -25,10 +25,10 @@
     "deleted": false,
     "deleted_records": [
         {
-            "$ref": "http://1Q1kG(^qr }"
+            "$ref": "http://1Q1kGqr"
         },
         {
-            "$ref": "http://1JSQu="
+            "$ref": "http://1JSQu"
         }
     ],
     "doi_prefixes": [
@@ -64,10 +64,10 @@
     "legacy_creation_date": "1970-01-15",
     "license": {
         "license": "consequat culpa ut",
-        "url": "http://1d%Zk;6myt"
+        "url": "http://1dZk6myt"
     },
     "new_record": {
-        "$ref": "http://1O`4>;Hd"
+        "$ref": "http://1O4Hd"
     },
     "proceedings": false,
     "public_notes": [
@@ -105,7 +105,7 @@
         {
             "curated_relation": true,
             "record": {
-                "$ref": "http://1$0"
+                "$ref": "http://10"
             },
             "relation": "commented",
             "relation_freetext": "esse"
@@ -129,14 +129,14 @@
         {
             "curated_relation": false,
             "record": {
-                "$ref": "http://1(^L_`9~"
+                "$ref": "http://1L9"
             },
             "relation": "predecessor",
             "relation_freetext": "Lorem non est ullamco dolor"
         }
     ],
     "self": {
-        "$ref": "http://1TC(XA_"
+        "$ref": "http://1TCXA_"
     },
     "short_title": "sit aliqua culpa esse ad",
     "title_variants": [
@@ -153,7 +153,7 @@
         },
         {
             "description": "id esse ut culpa",
-            "value": "http://1,%!mT.s\\~"
+            "value": "http://1mT.s"
         }
     ]
 }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -117,3 +117,28 @@ def test_validate_raises_on_invalid_date_time():
 
     with pytest.raises(ValidationError):
         utils.validate(data, schema)
+
+
+def test_validate_accepts_valid_uri_reference():
+    data = '/foo/bar'
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'uri-reference',
+    }
+
+    utils.validate(data, schema)
+
+
+def test_validate_raises_on_invalid_uri_reference():
+    data = '@[]'
+
+    schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'string',
+        'format': 'uri-reference',
+    }
+
+    with pytest.raises(ValidationError):
+        utils.validate(data, schema)

--- a/tests/unit/test_literature_builder.py
+++ b/tests/unit/test_literature_builder.py
@@ -168,7 +168,7 @@ def test_add_document():
         fulltext=True,
         hidden=True,
         material='preprint',
-        original_url='original_url',
+        original_url='http://www.example.com/original_url',
         source='source',
         url='url',
     )
@@ -180,7 +180,7 @@ def test_add_document():
             'hidden': True,
             'key': 'key',
             'material': 'preprint',
-            'original_url': 'original_url',
+            'original_url': 'http://www.example.com/original_url',
             'source': 'source',
             'url': 'url',
         },


### PR DESCRIPTION
* INCOMPATIBLE This replaces the `url` `format` everywhere by `uri` (for
absolute URLs) or `uri-reference` (if the URL could be relative).  These
`format`s are part of the JSON schema spec (the second one starting from
Draft 6), whereas `url` is not. In order to validate these formats, this
package now depends on `rfc3987`, and adds a custom validator for
`uri-reference`, as we are currently on Draft 4 (closes #274).

Note that the `json-schema-faker` currently generates relative URIs for
`uri` (which is incompatible with Draft 6), so the fixtures had to be
amended by hand.

Signed-off-by: Micha Moskovic <michamos@gmail.com>