### PR TITLE
elements: remove $schema from all elements

### DIFF
--- a/inspire_schemas/records/elements/acquisition_source.yml
+++ b/inspire_schemas/records/elements/acquisition_source.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     :MARC: ``541``

--- a/inspire_schemas/records/elements/address.yml
+++ b/inspire_schemas/records/elements/address.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     cities:

--- a/inspire_schemas/records/elements/arxiv_categories.yml
+++ b/inspire_schemas/records/elements/arxiv_categories.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     A category that currently exists on arXiv. Note that some categories have
     been renamed and are not in this list.  These are taken from the `arXiv API

--- a/inspire_schemas/records/elements/cnum.yml
+++ b/inspire_schemas/records/elements/cnum.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     The CNUM is based on the starting day of the conference, with an extra
     number appended to distinguish conferences starting on the first day.

--- a/inspire_schemas/records/elements/contact.yml
+++ b/inspire_schemas/records/elements/contact.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     Contact person's data

--- a/inspire_schemas/records/elements/country_code.yml
+++ b/inspire_schemas/records/elements/country_code.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     Country code according to `ISO 3166-1 alpha-2
     <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ with a few additions

--- a/inspire_schemas/records/elements/degree_type.yml
+++ b/inspire_schemas/records/elements/degree_type.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     The `other` value means that the degree type is not known or is not among
     the more specific values.

--- a/inspire_schemas/records/elements/document_type.yml
+++ b/inspire_schemas/records/elements/document_type.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 default: article
 enum:
 - activity report

--- a/inspire_schemas/records/elements/id.yml
+++ b/inspire_schemas/records/elements/id.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 anyOf:
 -   additionalProperties: false
     description: |-

--- a/inspire_schemas/records/elements/inspire_field.yml
+++ b/inspire_schemas/records/elements/inspire_field.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     :MARC: ``65017`` with ``2:INSPIRE``

--- a/inspire_schemas/records/elements/json_reference.yml
+++ b/inspire_schemas/records/elements/json_reference.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     $ref:

--- a/inspire_schemas/records/elements/language_code.yml
+++ b/inspire_schemas/records/elements/language_code.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     Language code according to `ISO 639-1
     <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_.

--- a/inspire_schemas/records/elements/material.yml
+++ b/inspire_schemas/records/elements/material.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     The possible values are:
 

--- a/inspire_schemas/records/elements/rank.yml
+++ b/inspire_schemas/records/elements/rank.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 enum:
 - STAFF
 - SENIOR

--- a/inspire_schemas/records/elements/records-files.yml
+++ b/inspire_schemas/records/elements/records-files.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     Describe information needed for files in records.
 properties:

--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     This is structurally very similar to a Literature record, with unnecessary

--- a/inspire_schemas/records/elements/related_record.yml
+++ b/inspire_schemas/records/elements/related_record.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     :MARC: ``78002``, ``78502``, ``78708```and ``510`` (depending on type of

--- a/inspire_schemas/records/elements/source.yml
+++ b/inspire_schemas/records/elements/source.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 description: |-
     Source of the information in this field. As several records can be merged,
     this information allows us to remember where every bit of metadata came

--- a/inspire_schemas/records/elements/title.yml
+++ b/inspire_schemas/records/elements/title.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 properties:
     source:

--- a/inspire_schemas/records/elements/url.yml
+++ b/inspire_schemas/records/elements/url.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/schema#
 additionalProperties: false
 description: |-
     :MARC: ``8564``

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -503,9 +503,6 @@ def load_schema(schema_name, resolved=False):
     with open(get_schema_path(schema_name, resolved)) as schema_fd:
         schema_data = json.loads(schema_fd.read())
 
-    if '$schema' not in schema_data:
-        schema_data = {'$schema': schema_data}
-
     return schema_data
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -229,22 +229,6 @@ def test_load_schema_with_schema_key(mock_get_schema_path, mock_open):
     assert loaded_schema == myschema
 
 
-@mock.patch('inspire_schemas.utils.open')
-@mock.patch('inspire_schemas.utils.get_schema_path')
-def test_load_schema_without_schema_key(mock_get_schema_path, mock_open):
-    myschema = {
-        'Sir Robin': 'The fleeing brave',
-    }
-    mock_open.side_effect = \
-        lambda x: contextlib.closing(six.StringIO(json.dumps(myschema)))
-    mock_get_schema_path.side_effect = \
-        lambda x, y: 'And his nostrils ripped and his bottom burned off'
-
-    loaded_schema = utils.load_schema('And gallantly he chickened out')
-
-    assert loaded_schema == {'$schema': myschema}
-
-
 def test_split_page_artid_page_range():
     page_string = '451-487'
     result = utils.split_page_artid(page_string)


### PR DESCRIPTION
Closes https://github.com/inspirehep/inspire-schemas/issues/279.

According to the spec, ``$schema`` MUST NOT appear in subschemas.
See: http://json-schema.org/latest/json-schema-core.html#rfc.section.7