### PR TITLE
hep: add identifier to _desy_bookkeeping

### DIFF
--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -41,7 +41,7 @@ properties:
         uniqueItems: true
     _desy_bookkeeping:
         description: |-
-            :MARC: ``595_D``
+            :MARC: ``595_D``, ``035__9:DESY``
 
             Used by DESY to store information about the keyword-assignment
             process.
@@ -55,6 +55,10 @@ properties:
                 expert:
                     description: |-
                         :MARC: ``595_Da``
+                    type: string
+                identifier:
+                    description: |-
+                        :MARC: ``035__z`` when ``035__a`` is ``DESY``
                     type: string
                 status:
                     description: |-

--- a/tests/integration/fixtures/hep_example.json
+++ b/tests/integration/fixtures/hep_example.json
@@ -8,27 +8,8 @@
         {
             "date": "deserunt laboris ad",
             "expert": "labore id Duis",
+            "identifier": "nisi sint",
             "status": "anim"
-        },
-        {
-            "date": "nulla fugiat D",
-            "expert": "ex ea",
-            "status": "nulla dolore nostrud"
-        },
-        {
-            "date": "sed et quis aliqua deserunt",
-            "expert": "Duis proident",
-            "status": "esse magna veniam u"
-        },
-        {
-            "date": "pariatur dolor sunt ut occaecat",
-            "expert": "elit enim",
-            "status": "tempor dolore laboris"
-        },
-        {
-            "date": "magna exercitation est",
-            "expert": "exercitation id laboris labore",
-            "status": "fugiat enim consequat reprehenderit"
         }
     ],
     "_export_to": {


### PR DESCRIPTION
* This field is meant to hold the `035__9:DESY` MARC field, that was
previously put among the `external_system_identifiers`. That was
incorrect, as the identifier is not unique nor external.

Signed-off-by: Micha Moskovic <michamos@gmail.com>