### PR TITLE
utils: filter_empty_parameters if all are empty

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -318,11 +318,11 @@ def filter_empty_parameters(func):
     def func_wrapper(self, *args, **kwargs):
         my_kwargs = {key: value for key, value in kwargs.items()
                      if value not in EMPTIES}
-        my_args = [arg for arg in args if arg not in EMPTIES]
+        args_is_empty = all(arg in EMPTIES for arg in args)
 
         if (
                 {'source', 'material'}.issuperset(my_kwargs) or not my_kwargs
-        ) and not my_args:
+        ) and args_is_empty:
             return
         return func(self, *args, **my_kwargs)
 

--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -318,10 +318,11 @@ def filter_empty_parameters(func):
     def func_wrapper(self, *args, **kwargs):
         my_kwargs = {key: value for key, value in kwargs.items()
                      if value not in EMPTIES}
+        my_args = [arg for arg in args if arg not in EMPTIES]
 
         if (
                 {'source', 'material'}.issuperset(my_kwargs) or not my_kwargs
-        ) and args == ():
+        ) and not my_args:
             return
         return func(self, *args, **my_kwargs)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -713,3 +713,20 @@ def test_author_id_normalize_and_schema_unknown():
 def test_author_id_normalize_and_schema_conflict():
     with pytest.raises(errors.SchemaUIDConflict):
         utils.author_id_normalize_and_schema('SLAC-123456', 'CERN')
+
+
+@pytest.mark.parametrize('arg1,arg2,source,material', [
+    ('value', 'another', None, None),
+    ('value', None, None, None),
+    ('', [], None, None),
+    (None, None, 'source', None),
+    (None, None, None, 'material'),
+])
+def test_filter_empty_parameters(arg1, arg2, source, material):
+    @utils.filter_empty_parameters
+    def function_no_empty_args(arg1, arg2, source=None, material=None):
+        if arg1 or arg2:
+            return
+        assert False
+
+    function_no_empty_args(arg1, arg2, source=source, material=material)


### PR DESCRIPTION
This fixes an issue with `filter_empty_parameters` where if all arguments provided to a decorated function as args (as opposed to kwargs) are empty, the filtered function would still be executed on all-empty arguments.

Can be reproduced by calling `LiteratureBuilder().add_abstract(None)`.