### PR TITLE
elements.reference: allow repeated authors

### DIFF
--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -40,7 +40,7 @@ properties:
         minItems: 1
         title: List of authors
         type: array
-        uniqueItems: true
+        uniqueItems: false
     book_series:
         additionalProperties: false
         properties:


### PR DESCRIPTION
It can happen, that even if authors don't share a name, they may share initials in the references. With lack of other discerning information, we should allow them to be duplicated.

[Example](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.7.041053), reference 43.