### PR TITLE
utils: handle parentheses in collaborations

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -653,6 +653,10 @@ def normalize_collaboration(collaboration):
     if not collaboration:
         return []
 
+    collaboration = collaboration.strip()
+    if collaboration.startswith('(') and collaboration.endswith(')'):
+        collaboration = collaboration[1:-1]
+
     collaborations = _RE_AND.split(collaboration)
     collaborations = (_RE_COLLABORATION_LEADING.sub('', collab)
                       for collab in collaborations)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -310,6 +310,16 @@ def test_normalize_collaboration_splits_and_removes_fluff():
     assert utils.normalize_collaboration(collaboration) == ['CMS', 'ATLAS']
 
 
+def test_normalize_collaboration_handles_parentheses():
+    collaboration = '(ATLAS Collaboration)'
+    assert utils.normalize_collaboration(collaboration) == ['ATLAS']
+
+
+def test_normalize_collaboration_handles_parentheses():
+    collaboration = '(for the CMS and ATLAS Collaborations)'
+    assert utils.normalize_collaboration(collaboration) == ['CMS', 'ATLAS']
+
+
 def test_get_license_from_url_handles_none():
     assert utils.get_license_from_url(None) is None
 


### PR DESCRIPTION
Removes matching parentheses during collaborations normalization