### PR TITLE
elements/reference: urls don't have to be URIs

### DIFF
--- a/inspire_schemas/records/elements/reference.yml
+++ b/inspire_schemas/records/elements/reference.yml
@@ -251,9 +251,20 @@ properties:
             :MARC: ``999C5t``
     urls:
         items:
-            $ref: url.json
+            additionalProperties: false
             description: |-
                 :MARC: ``999C5u``
+            properties:
+                description:
+                    minLength: 1
+                    type: string
+                value:
+                    minLength: 1
+                    type: string
+            required:
+            - value
+            title: URL of related document
+            type: object
         minItems: 1
         type: array
         uniqueItems: true


### PR DESCRIPTION
The strings contained in `urls.value` are often not well-formed URIs.
In order not to make a large number of records fail migration, this
commit effectively removes the `format: uri` constraint on that field.