### PR TITLE
builders: reference: add more fields to publisher

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -28,6 +28,7 @@ import re
 
 import six
 from inspire_utils.name import normalize_name
+from inspire_utils.date import normalize_date
 from isbn import ISBN
 
 import idutils
@@ -240,9 +241,14 @@ class ReferenceBuilder(object):
         else:
             self.add_misc(pubnote)
 
-    def set_publisher(self, publisher):
+    def set_publisher(self, publisher, place=None, date=None):
         self._ensure_reference_field('imprint', {})
-        self.obj['reference']['imprint']['publisher'] = publisher
+        imprint = self.obj['reference']['imprint']
+        imprint['publisher'] = publisher
+        if place:
+            imprint['place'] = place
+        if date:
+            imprint['date'] = normalize_date(date)
 
     def add_report_number(self, repno):
         # For some reason we get more recall by trying the first part in

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -695,6 +695,31 @@ def test_set_publisher():
     assert expected == result
 
 
+def test_set_publisher_place_date():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_publisher('Elsevier', place='New York', date='23/12/2015')
+
+    expected = [
+        {
+            'reference': {
+                'imprint': {
+                    'publisher': 'Elsevier',
+                    'place': 'New York',
+                    'date': '2015-12-23',
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 def test_add_report_number_handles_several_report_numbers():
     schema = load_schema('hep')
     subschema = schema['properties']['references']


### PR DESCRIPTION
This adds support for `place` and `date` in `set_publisher`.

Signed-off-by: Szymon Łopaciuk <szymon.lopaciuk@cern.ch>