### PR TITLE
builders: references: add imprint date and place

### DIFF
--- a/inspire_schemas/builders/references.py
+++ b/inspire_schemas/builders/references.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 import re
 
 import six
+from inspire_utils.date import normalize_date
 from inspire_utils.name import normalize_name
 from isbn import ISBN
 
@@ -243,6 +244,14 @@ class ReferenceBuilder(object):
     def set_publisher(self, publisher):
         self._ensure_reference_field('imprint', {})
         self.obj['reference']['imprint']['publisher'] = publisher
+
+    def set_imprint_date(self, date):
+        self._ensure_reference_field('imprint', {})
+        self.obj['reference']['imprint']['date'] = normalize_date(date)
+
+    def set_imprint_place(self, place):
+        self._ensure_reference_field('imprint', {})
+        self.obj['reference']['imprint']['place'] = place
 
     def add_report_number(self, repno):
         # For some reason we get more recall by trying the first part in

--- a/tests/unit/test_reference_builder.py
+++ b/tests/unit/test_reference_builder.py
@@ -695,6 +695,52 @@ def test_set_publisher():
     assert expected == result
 
 
+def test_set_imprint_date():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_imprint_date('23/12/2015')
+
+    expected = [
+        {
+            'reference': {
+                'imprint': {
+                    'date': '2015-12-23',
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_set_imprint_place():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    builder = ReferenceBuilder()
+
+    builder.set_imprint_place('New York')
+
+    expected = [
+        {
+            'reference': {
+                'imprint': {
+                    'place': 'New York',
+                },
+            },
+        },
+    ]
+    result = [builder.obj]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 def test_add_report_number_handles_several_report_numbers():
     schema = load_schema('hep')
     subschema = schema['properties']['references']


### PR DESCRIPTION
Supersedes #300. This adds setters for imprint date and place. I called them `set_imprint_*` as I think `set_publication_date` could be ambiguous with `publication_info.year` field.