### PR TITLE
data: add dois field

### DIFF
--- a/inspire_schemas/records/data.yml
+++ b/inspire_schemas/records/data.yml
@@ -46,6 +46,29 @@ properties:
         minItems: 1
         type: array
         uniqueItems: true
+    dois:
+        items:
+            additionalProperties: false
+            properties:
+                source:
+                    $ref: elements/source.json
+                    description: |-
+                        :MARC: ``0247_9``
+                value:
+                    description: |-
+                        :MARC: ``0247_a``
+                        :example: ``10.1023/A:1026654312961``
+                    minLength: 1
+                    pattern: ^10\.\d+(\.\d+)?/\S+$
+                    title: DOI
+                    type: string
+            required:
+            - value
+            type: object
+        minItems: 1
+        title: List of DOIs
+        type: array
+        uniqueItems: true
     new_record:
         $ref: elements/json_reference.json
         description: |-

--- a/tests/integration/fixtures/data_example.json
+++ b/tests/integration/fixtures/data_example.json
@@ -12,6 +12,20 @@
             "$ref": "http://V"
         }
     ],
+    "dois": [
+        {
+            "source": "velit",
+            "value": "10.1.61/\\mns"
+        },
+        {
+            "source": "dolor Excepteur sunt non sit",
+            "value": "10.58800147053/M_fs\\hh/s%1"
+        },
+        {
+            "source": "exercitation consequat",
+            "value": "10.6654905497/2%(NVj<"
+        }
+    ],
     "new_record": {
         "$ref": "http://H34fYq-6"
     },


### PR DESCRIPTION
* NEW adds the `dois` field to the Data schema, which needs to be
populated in order to track citations to Data.