### PR TITLE
doctests: skip unicode result test

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -394,7 +394,7 @@ def normalize_arxiv_category(category):
 
     Example:
         >>> from inspire_schemas.utils import normalize_arxiv_category
-        >>> normalize_arxiv_category('funct-an')
+        >>> normalize_arxiv_category('funct-an')  # doctest: +SKIP
         u'math.FA'
 
     """


### PR DESCRIPTION
It turns out that it's not even doable without major rework on 3rd
parties.

See https://stackoverflow.com/questions/42158733/unicode-literals-and-doctest-in-python-2-7-and-python-3-5

Signed-off-by: David Caro <david@dcaro.es>