### PR TITLE
records: fix author_schema description

### DIFF
--- a/inspire_schemas/records/authors.yml
+++ b/inspire_schemas/records/authors.yml
@@ -158,8 +158,8 @@ properties:
             properties:
                 current:
                     description: |-
-                        :MARC: if ``true``, the email comes from ``o``, if
-                            ``false``, from ``m``.
+                        :MARC: if ``true``, the email comes from ``m``, if
+                            ``false``, from ``o``.
                     title: Whether this address is still in use
                     type: boolean
                 hidden:


### PR DESCRIPTION
The meaning of the fields ``371__o`` and ``371__m`` were inverted. ``o`` means old, so ``current`` should be False.

Signed-off-by: Victor Balbuena <vbalbp@gmail.com>