### PR TITLE
utils: accept letters mid-volume in pub_info conversion

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -64,7 +64,7 @@ _RE_LICENSE_URL = re.compile(
     r'^/licenses/(?P<sublicense>[-\w]*)(?:/(?P<version>[\.\d]*))?'
 )
 _RE_VOLUME_STARTS_WITH_A_LETTER = re.compile(
-    r'^(?P<letter>[A-Z])(?P<volume>\d+)', re.IGNORECASE
+    r'^(?P<letter>[A-Z])(?P<volume>\d[\dA-Z]*$)', re.IGNORECASE
 )
 _RE_VOLUME_ENDS_WITH_A_LETTER = re.compile(
     r'(?P<volume>\d+)(?P<letter>[A-Z])$', re.IGNORECASE

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,8 @@ def do_setup():
             'pyyaml',
             'rfc3987',
             'six',
+            # requests requires a urllib3 version of 1.23, we pin it down here to solve dependency problems
+            'urllib3==1.23',
         ],
         tests_require=tests_require,
         extras_require=extras_require,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -669,6 +669,33 @@ def test_convert_old_publication_info_to_new_does_not_raise_when_deducing_year_f
     assert expected == result
 
 
+def test_convert_old_publication_info_to_new_handles_volumes_with_letters_in_the_middle():
+    schema = utils.load_schema('hep')
+    subschema = schema['properties']['publication_info']
+
+    publication_info = [
+        {
+            'journal_record': {
+                '$ref': 'http://localhost:5000/api/journals/725825',
+            },
+            'journal_title': 'Eur.Phys.J.',
+            'journal_volume': 'A28S1',
+        },
+    ]
+    assert utils.validate(publication_info, subschema) is None
+
+    expected = [
+        {
+            'journal_title': 'Eur.Phys.J.A',
+            'journal_volume': '28S1',
+        },
+    ]
+    result = utils.convert_old_publication_info_to_new(publication_info)
+
+    assert utils.validate(result, subschema) is None
+    assert expected == result
+
+
 def test_convert_new_publication_info_to_old():
     schema = utils.load_schema('hep')
     subschema = schema['properties']['publication_info']
@@ -797,6 +824,30 @@ def test_convert_new_publication_info_to_old_handles_year_added_to_volumes():
             'year': 2017,
             'page_start': '137',
         }
+    ]
+    result = utils.convert_new_publication_info_to_old(publication_info)
+
+    assert utils.validate(result, subschema) is None
+    assert expected == result
+
+
+def test_convert_new_publication_info_to_old_handles_volumes_with_letters_in_the_middle():
+    schema = utils.load_schema('hep')
+    subschema = schema['properties']['publication_info']
+
+    publication_info = [
+        {
+            'journal_title': 'Eur.Phys.J.A',
+            'journal_volume': '28S1',
+        },
+    ]
+    assert utils.validate(publication_info, subschema) is None
+
+    expected = [
+        {
+            'journal_title': 'Eur.Phys.J.',
+            'journal_volume': 'A28S1',
+        },
     ]
     result = utils.convert_new_publication_info_to_old(publication_info)
 


### PR DESCRIPTION
When converting journals from Legacy to Labs,
```
'journal_title': 'Phys.Rev.',
'journal_volume': 'D43',
```
turns into
```
'journal_title': 'Phys.Rev.D',
'journal_volume': '43',
```
.
Previously,
```
'journal_title': 'Eur.Phys.J.', 
'journal_volume': 'A28S1',
```
would turn into
```
'journal_title': 'Eur.Phys.J.A', 
'journal_volume': '28',
```
with the fix made in this PR, it would turn into
```
'journal_title': 'Eur.Phys.J.A', 
'journal_volume': '28S1',
```
as it's expected.

Signed-off-by: Victor Balbuena <vbalbp@gmail.com>