### PR TITLE
builders: fix author position sorting

### DIFF
--- a/inspire_schemas/builders/authors.py
+++ b/inspire_schemas/builders/authors.py
@@ -34,7 +34,9 @@ from ..utils import EMPTIES, filter_empty_parameters, load_schema
 
 
 RANKS = load_schema('elements/rank')['enum']
+RANKS.append(None)
 INSTITUTION_RANK_TO_PRIORITY = {rank: -idx for (idx, rank) in enumerate(RANKS)}
+EARLIEST_DATE = PartialDate.loads('1000')
 
 
 class AuthorBuilder(object):
@@ -296,7 +298,7 @@ class AuthorBuilder(object):
         start_date = work.get('start_date')
         return (
             work.get('current'),
-            PartialDate.parse(start_date) if start_date else None,
+            PartialDate.parse(start_date) if start_date else EARLIEST_DATE,
         )
 
     @filter_empty_parameters

--- a/tests/unit/test_author_builder.py
+++ b/tests/unit/test_author_builder.py
@@ -440,6 +440,7 @@ def test_add_institution_sorts_by_start_date():
     author = AuthorBuilder()
     author.add_institution(institution='First University',
                            start_date='1950-02-01')
+    author.add_institution(institution='Dateless University')
     author.add_institution(institution='Colgate University',
                            start_date='1994-02-01')
 
@@ -453,6 +454,11 @@ def test_add_institution_sorts_by_start_date():
         {
             "institution": 'First University',
             "start_date": u'1950-02-01',
+            "curated_relation": False,
+            "current": False
+        },
+        {
+            "institution": 'Dateless University',
             "curated_relation": False,
             "current": False
         }
@@ -482,6 +488,7 @@ def test_add_institution_sorts_by_rank():
                            rank='OTHER')
     author.add_institution(institution='Colgate University',
                            rank='UNDERGRADUATE')
+    author.add_institution(institution='Colgate University')
     author.add_institution(institution='Colgate University',
                            rank='POSTDOC')
     author.add_institution(institution='Colgate University',
@@ -539,6 +546,11 @@ def test_add_institution_sorts_by_rank():
         {
             "institution": 'Colgate University',
             "rank": 'OTHER',
+            "curated_relation": False,
+            "current": False
+        },
+        {
+            "institution": 'Colgate University',
             "curated_relation": False,
             "current": False
         },


### PR DESCRIPTION
* Fixes the sorting when there are positions with and without start_date

* Fixes the sorting when there are positions with and without rank