### PR TITLE
readers: more robust ConferenceReader.city

### DIFF
--- a/inspire_schemas/readers/conference.py
+++ b/inspire_schemas/readers/conference.py
@@ -44,7 +44,7 @@ class ConferenceReader(object):
             'Tokyo'
 
         """
-        return get_value(self.record, 'address[0].cities[0]', default='')
+        return get_value(self.record, 'address.cities[0][0]', default='')
 
     @property
     def country(self):

--- a/tests/unit/test_conference_reader.py
+++ b/tests/unit/test_conference_reader.py
@@ -49,6 +49,30 @@ def test_city():
     assert expected == result
 
 
+def test_city_when_no_city_in_first_address():
+    schema = load_schema('conferences')
+    subschema = schema['properties']['address']
+
+    record = {
+        'address': [
+            {
+                'place_name': 'Lido di Venezia',
+            },
+            {
+                'cities': [
+                    'Venice',
+                ],
+            },
+        ],
+    }
+    assert validate(record['address'], subschema) is None
+
+    expected = 'Venice'
+    result = ConferenceReader(record).city
+
+    assert expected == result
+
+
 def test_country():
     schema = load_schema('conferences')
     subschema = schema['properties']['address']


### PR DESCRIPTION
Fixes a bug in the HAL push for some conference papers when the conference record contains a first address with no city, e.g. https://inspirehep.net/record/1651547.

cc @mathieugrives