### PR TITLE
builder: add email address with hidden field

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,11 +25,11 @@
 from __future__ import print_function
 
 import os
+import shutil
 from io import open
 
 from autosemver.packaging import get_changelog, get_current_version
 from jsonschema2rst.parser_runner import run_parser
-import shutil
 
 
 def _generate_schemas_doc():

--- a/inspire_schemas/builders/authors.py
+++ b/inspire_schemas/builders/authors.py
@@ -110,18 +110,28 @@ class AuthorBuilder(object):
         self.obj['name'].setdefault('native_names', []).append(name)
 
     @filter_empty_parameters
-    def add_email_address(self, email):
+    def add_email_address(self, email, hidden=None):
         """Add email address.
 
         Args:
-            :param email: public email of the author.
+            :param email: email of the author.
             :type email: string
+
+            :param hidden: if email is public or not.
+            :type hidden: boolean
         """
-        existing_emails = get_value(self.obj, 'email_addresses.value', [])
-        if email not in existing_emails:
-            self._append_to('email_addresses', {
-                "value": email
-            })
+        existing_emails = get_value(self.obj, 'email_addresses', [])
+        found_email = next(
+            (existing_email for existing_email in existing_emails if existing_email.get('value') == email),
+            None
+        )
+        if found_email is None:
+            new_email = {'value': email}
+            if hidden is not None:
+                new_email['hidden'] = hidden
+            self._append_to('email_addresses', new_email)
+        elif hidden is not None:
+            found_email['hidden'] = hidden
 
     @filter_empty_parameters
     def set_status(self, status):

--- a/tests/unit/test_author_builder.py
+++ b/tests/unit/test_author_builder.py
@@ -219,6 +219,59 @@ def test_add_email_addresses_skips_duplicate_ones():
     assert expected == result
 
 
+def test_add_email_addresses_with_hidden_parameter():
+    schema = load_schema('authors')
+    subschema = schema['properties']['email_addresses']
+
+    author = AuthorBuilder()
+    author.add_email_address('example@test.com', hidden=True)
+
+    expected = [{
+        "value": 'example@test.com',
+        "hidden": True,
+    }]
+    result = author.obj['email_addresses']
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_add_email_addresses_with_hidden_parameter_only_updates_hidden_field():
+    schema = load_schema('authors')
+    subschema = schema['properties']['email_addresses']
+
+    author = AuthorBuilder()
+    author.add_email_address('example@test.com')
+    author.add_email_address('example@test.com', hidden=False)
+
+    expected = [{
+        "value": 'example@test.com',
+        "hidden": False,
+    }]
+    result = author.obj['email_addresses']
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_add_email_addresses_without_hidden_parameter_skip_updates_hidden_field():
+    schema = load_schema('authors')
+    subschema = schema['properties']['email_addresses']
+
+    author = AuthorBuilder()
+    author.add_email_address('example@test.com', hidden=True)
+    author.add_email_address('example@test.com')
+
+    expected = [{
+        "value": 'example@test.com',
+        "hidden": True,
+    }]
+    result = author.obj['email_addresses']
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 def test_set_status():
     schema = load_schema('authors')
     subschema = schema['properties']['status']


### PR DESCRIPTION
* Adds or updates (if hidden is not None) with `hidden` field to
indicate if email is public or not.

* NSPIR-2157