### PR TITLE
literature builder: add external_system_identifier

### DIFF
--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE-SCHEMAS.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # INSPIRE-SCHEMAS is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -689,6 +689,21 @@ class LiteratureBuilder(object):
         """
         self._append_to('urls', {
             'value': url
+        })
+
+    @filter_empty_parameters
+    def add_external_system_identifier(self, extid, schema):
+        """Add external system identifier to ``external_system_identifiers``.
+
+        :param extid: external system identifier for the current document
+        :type extid: string
+
+        :param schema: identifies the external system for the given identifier
+        :type schema: string
+        """
+        self._append_to('external_system_identifiers', {
+            'schema': schema,
+            'value': extid,
         })
 
     @filter_empty_parameters

--- a/tests/unit/test_literature_builder.py
+++ b/tests/unit/test_literature_builder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE-SCHEMAS.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2019 CERN.
 #
 # INSPIRE-SCHEMAS is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -630,3 +630,69 @@ def test_make_author_handles_none_in_id_schema():
 
     assert validate([result], subschema) is None
     assert expected == result
+
+
+def test_add_external_system_identifier():
+    schema = load_schema('hep')
+    subschema = schema['properties']['external_system_identifiers']
+    builder = LiteratureBuilder()
+    builder.add_external_system_identifier('12345', 'osti')
+
+    result = builder.record['external_system_identifiers']
+    expected = [
+        {
+            'value': '12345',
+            'schema': 'osti',
+        }
+    ]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_add_many_external_system_identifier():
+    schema = load_schema('hep')
+    subschema = schema['properties']['external_system_identifiers']
+    builder = LiteratureBuilder()
+    builder.add_external_system_identifier('5758037', 'osti')
+    builder.add_external_system_identifier('1992PhRvD..45..124K', 'ADS')
+
+    result = builder.record['external_system_identifiers']
+    expected = [
+        {
+            'value': '5758037',
+            'schema': 'osti',
+        },
+        {
+            'value': '1992PhRvD..45..124K',
+            'schema': 'ADS',
+        },
+    ]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_add_external_system_identifier_kwargs():
+    schema = load_schema('hep')
+    subschema = schema['properties']['external_system_identifiers']
+    builder = LiteratureBuilder()
+    builder.add_external_system_identifier(schema='osti', extid='12345')
+
+    result = builder.record['external_system_identifiers']
+    expected = [
+        {
+            'value': '12345',
+            'schema': 'osti',
+        }
+    ]
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
+def test_add_external_system_identifier_empty_kwargs():
+    builder = LiteratureBuilder()
+    builder.add_external_system_identifier(schema='', extid='')
+
+    assert 'external_system_identifiers' not in builder.record


### PR DESCRIPTION
When harvesting OSTI via hepcrawl the `osti-id` of the record should be added to the literature record as `external_system_identifier`. This adds the necessary method to the LiteratureBuilder.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>