### PR TITLE
schemas: Update all schemas for invenio compatibility

### DIFF
--- a/inspire_schemas/records/authors.yml
+++ b/inspire_schemas/records/authors.yml
@@ -5,6 +5,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:

--- a/inspire_schemas/records/conferences.yml
+++ b/inspire_schemas/records/conferences.yml
@@ -5,6 +5,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:

--- a/inspire_schemas/records/data.yml
+++ b/inspire_schemas/records/data.yml
@@ -7,6 +7,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         description: |-
             :MARC: ``980__a``

--- a/inspire_schemas/records/elements/records-files.yml
+++ b/inspire_schemas/records/elements/records-files.yml
@@ -19,5 +19,8 @@ properties:
     version_id:
         minLength: 1
         type: string
+    file_id:
+        minLength: 1
+        type: string
 title: File schema.
 type: object

--- a/inspire_schemas/records/experiments.yml
+++ b/inspire_schemas/records/experiments.yml
@@ -8,6 +8,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:

--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -5,6 +5,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         description: |-
             :MARC: ``980__a`` (``HEP`` maps to ``Literature``)

--- a/inspire_schemas/records/institutions.yml
+++ b/inspire_schemas/records/institutions.yml
@@ -25,6 +25,16 @@ properties:
         title: List of affiliation identifiers
         type: array
         uniqueItems: true
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:

--- a/inspire_schemas/records/jobs.yml
+++ b/inspire_schemas/records/jobs.yml
@@ -5,6 +5,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:

--- a/inspire_schemas/records/journals.yml
+++ b/inspire_schemas/records/journals.yml
@@ -5,6 +5,16 @@ properties:
         format: uri
         minLength: 1
         type: string
+    _bucket:
+        description: |-
+            Used by `invenio-records-files` to store information about the
+            bucket attached to this record.
+
+            .. note::
+
+                This field is maintained by `invenio-records-files` and should
+                not be edited manually.
+        type: string
     _collections:
         items:
             enum:


### PR DESCRIPTION
`Invenio-records-files` introduced `_bucket` key added to every record
instance, also latest version adds `file_id` to `_files` file entry.

INSPIR-2589