### PR TITLE
builders: refactor using inheritance

### DIFF
--- a/inspire_schemas/builders/__init__.py
+++ b/inspire_schemas/builders/__init__.py
@@ -26,9 +26,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+from .authors import AuthorBuilder  # noqa
+from .conferences import ConferenceBuilder  # noqa
+from .jobs import JobBuilder  # noqa
 from .literature import LiteratureBuilder  # noqa
 from .references import ReferenceBuilder  # noqa
 from .signatures import SignatureBuilder  # noqa
-from .authors import AuthorBuilder  # noqa
-from .jobs import JobBuilder  # noqa
-from .conferences import ConferenceBuilder  # noqa

--- a/inspire_schemas/builders/authors.py
+++ b/inspire_schemas/builders/authors.py
@@ -24,14 +24,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-
+from inspire_schemas.builders.builder import RecordBuilder
+from inspire_schemas.utils import filter_empty_parameters, load_schema
 from inspire_utils.date import normalize_date, PartialDate
 from inspire_utils.helpers import force_list
 from inspire_utils.name import normalize_name
 from inspire_utils.record import get_value
-
-from ..utils import EMPTIES, filter_empty_parameters, load_schema
-
 
 RANKS = load_schema('elements/rank')['enum']
 RANKS.append(None)
@@ -39,42 +37,14 @@ INSTITUTION_RANK_TO_PRIORITY = {rank: -idx for (idx, rank) in enumerate(RANKS)}
 EARLIEST_DATE = PartialDate.loads('1000')
 
 
-class AuthorBuilder(object):
+class AuthorBuilder(RecordBuilder):
     """Author record builder."""
+
+    _collections = ['Authors']
+
     def __init__(self, author=None, source=None):
-        if author is None:
-            author = {
-                '_collections': ['Authors'],
-            }
-        self.obj = author
-        self.source = source
-
-    def _ensure_field(self, field_name, value):
-        if field_name not in self.obj:
-            self.obj[field_name] = value
-
-    def _sourced_dict(self, source=None, **kwargs):
-        """Like ``dict(**kwargs)``, but where the ``source`` key is special."""
-        if source:
-            kwargs['source'] = source
-        elif self.source:
-            kwargs['source'] = self.source
-        return kwargs
-
-    def _append_to(self, field, element):
-        """Append the ``element`` to the ``field`` of the record.
-
-        This method is smart: it does nothing if ``element`` is empty and
-        creates ``field`` if it does not exit yet.
-
-        Args:
-            :param field: the name of the field of the record to append to
-            :type field: string
-            :param element: the element to append
-        """
-        if element not in EMPTIES:
-            self.obj.setdefault(field, [])
-            self.obj.get(field).append(element)
+        super(AuthorBuilder, self).__init__(author, source)
+        self.obj = self.record
 
     @filter_empty_parameters
     def set_name(self, name):

--- a/inspire_schemas/builders/builder.py
+++ b/inspire_schemas/builders/builder.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE-SCHEMAS.
+# Copyright (C) 2019 CERN.
+#
+# INSPIRE-SCHEMAS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE-SCHEMAS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE-SCHEMAS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import six
+
+from ..utils import EMPTIES, filter_empty_parameters
+
+
+class RecordBuilder(object):
+    """Base record builder."""
+
+    _collections = []
+
+    def __init__(self, record=None, source=None):
+        if record is None:
+            record = {'_collections': [_ for _ in self.__class__._collections]}
+        self.record = record
+        self.source = source
+
+    def __repr__(self):
+        """Printable representation of the builder."""
+        return u'{}(source={!r}, record={})'.format(
+            type(self).__name__,
+            self.source,
+            self.record
+        )
+
+    @filter_empty_parameters
+    def _append_to(self, field, element=None, default_list=None, **kwargs):
+        if default_list is None:
+            default_list = []
+        if element not in EMPTIES:
+            self._ensure_list_field(field, default_list)
+            if element not in self.record[field]:
+                self.record[field].append(element)
+        elif kwargs:
+            if 'record' in kwargs and isinstance(kwargs['record'], six.string_types):
+                kwargs['record'] = {'$ref': kwargs['record']}
+            self._ensure_list_field(field, default_list)
+            if kwargs not in self.record[field]:
+                self.record[field].append(kwargs)
+
+    def _ensure_field(self, field_name, default_value, obj=None):
+        if obj is None:
+            obj = self.record
+        if field_name not in obj:
+            obj[field_name] = default_value
+
+    def _ensure_list_field(self, field_name, default_value=None, obj=None):
+        if default_value is None:
+            default_value = []
+        self._ensure_field(field_name, default_value, obj)
+
+    def _ensure_dict_field(self, field_name, default_value=None, obj=None):
+        if default_value is None:
+            default_value = {}
+        self._ensure_field(field_name, default_value, obj)
+
+    def _sourced_dict(self, source=None, **kwargs):
+        if source:
+            kwargs['source'] = source
+        elif self.source:
+            kwargs['source'] = self.source
+        return kwargs

--- a/inspire_schemas/builders/conferences.py
+++ b/inspire_schemas/builders/conferences.py
@@ -23,85 +23,24 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Conferences builder class and related code."""
+
+from __future__ import absolute_import, division, print_function
+
 import six
 
+from inspire_schemas.builders.builder import RecordBuilder
 from inspire_schemas.utils import (
-    validate, filter_empty_parameters, EMPTIES, sanitize_html
+    filter_empty_parameters,
+    sanitize_html,
+    validate,
 )
 from inspire_utils.date import normalize_date
 
 
-class ConferenceBuilder(object):
+class ConferenceBuilder(RecordBuilder):
     """Conference record builder."""
 
-    def __init__(self, record=None, source=None):
-        """Initialize builder with provided source and/or conference record.
-
-        Args:
-            record (dict): sets the default value for the the current record,
-            in order to edit an already existent record.
-            source (string): sets the default value for the source fields of the
-            current job record, which captures where the information that the
-            builder populates comes from.
-        """
-        if record is None:
-            record = {
-                '_collections': ['Conferences'],
-            }
-        self.record = record
-        self.source = source
-
-    def _ensure_field(self, field_name, default_value, obj=None):
-        if obj is None:
-            obj = self.record
-        if field_name not in obj:
-            obj.update({field_name: default_value})
-
-    def _ensure_list_field(self, field_name, default_value=None, obj=None):
-        if default_value is None:
-            default_value = []
-        self._ensure_field(field_name, default_value, obj)
-
-    def _ensure_dict_field(self, field_name, default_value=None, obj=None):
-        if default_value is None:
-            default_value = {}
-        self._ensure_field(field_name, default_value, obj)
-
-    def _sourced_dict(self, source=None, **kwargs):
-        """Like ``dict(**kwargs)``, but where the ``source`` key is special."""
-        if source:
-            kwargs['source'] = source
-        elif self.source:
-            kwargs['source'] = self.source
-        return kwargs
-
-    @filter_empty_parameters
-    def _append_to(self, field, element=None, default_list=None, **kwargs):
-        """Append the ``element`` to the ``field`` of the record.
-
-        This method is ``smart``: it does nothing if ``element`` is empty and
-        creates ``field`` if it does not exit yet.
-
-        Args:
-            field (string): the name of the field of the record to append to
-            element: the element to append
-            default_list (list): Default list which should be sert when field is missing
-
-        Kwargs:
-            Arguments from which a dictionary will be built if element is empty
-        """
-        if default_list is None:
-            default_list = []
-        if element not in EMPTIES:
-            self._ensure_list_field(field, default_list)
-            if element not in self.record[field]:
-                self.record[field].append(element)
-        elif kwargs:
-            if 'record' in kwargs and isinstance(kwargs['record'], six.string_types):
-                kwargs['record'] = {'$ref': kwargs['record']}
-            self._ensure_list_field(field, default_list)
-            if kwargs not in self.record[field]:
-                self.record[field].append(kwargs)
+    _collections = ['Conferences']
 
     @staticmethod
     def _prepare_url(value, description=None):

--- a/inspire_schemas/builders/jobs.py
+++ b/inspire_schemas/builders/jobs.py
@@ -23,89 +23,34 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Jobs builder class and related code."""
+
+from __future__ import absolute_import, division, print_function
+
 import logging
+
 import six
 from jsonschema._format import is_email
 
+from inspire_schemas.builders.builder import RecordBuilder
 from inspire_schemas.utils import (
-    validate, filter_empty_parameters, EMPTIES,
-    sanitize_html
+    filter_empty_parameters,
+    sanitize_html,
+    validate,
 )
 from inspire_utils.date import normalize_date
-
 
 LOG = logging.getLogger(__name__)
 
 
-class JobBuilder(object):
+class JobBuilder(RecordBuilder):
     """Job record builder."""
 
+    _collections = ['Jobs']
+
     def __init__(self, record=None, source=None,):
-        """Initialize builder with provided source and/or job record
-
-        Args:
-            source (string): sets the default value for the source fields of the current
-            job record, which captures where the information that the builder populates
-            comes from
-            record (dict): sets the default value for the the current record, in order
-            to edit an already existent record
-        """
+        super(JobBuilder, self).__init__(record, source)
         if record is None:
-            record = {
-                '_collections': ['Jobs'],
-                'status': 'pending'
-            }
-        self.record = record
-        self.source = source
-
-    def _ensure_field(self, field_name, default_value, obj=None):
-        if obj is None:
-            obj = self.record
-        if field_name not in obj:
-            obj.update({field_name: default_value})
-
-    def _ensure_list_field(self, field_name, default_value=None, obj=None):
-        if default_value is None:
-            default_value = []
-        self._ensure_field(field_name, default_value, obj)
-
-    def _ensure_dict_field(self, field_name, default_value=None, obj=None):
-        if default_value is None:
-            default_value = {}
-        self._ensure_field(field_name, default_value, obj)
-
-    def _sourced_dict(self, source=None, **kwargs):
-        """Like ``dict(**kwargs)``, but where the ``source`` key is special."""
-        if source:
-            kwargs['source'] = source
-        elif self.source:
-            kwargs['source'] = self.source
-        return kwargs
-
-    @filter_empty_parameters
-    def _append_to(self, field, element=None, default_list=None, **kwargs):
-        """Append the ``element`` to the ``field`` of the record.
-        This method is ``smart``: it does nothing if ``element`` is empty and
-            creates ``field`` if it does not exit yet.
-        Args:
-
-            field (string): the name of the field of the record to append to
-            element: the element to append
-            default_list (list): Default list which should be sert when field is missing
-        Kwargs: Arguments from which a dictionary will be built if element is empty
-        """
-        if default_list is None:
-            default_list = []
-        if element not in EMPTIES:
-            self._ensure_list_field(field, default_list)
-            if element not in self.record[field]:
-                self.record[field].append(element)
-        elif kwargs:
-            if 'record' in kwargs and isinstance(kwargs['record'], six.string_types):
-                kwargs['record'] = {'$ref': kwargs['record']}
-            self._ensure_list_field(field, default_list)
-            if kwargs not in self.record[field]:
-                self.record[field].append(kwargs)
+            self.record['status'] = 'pending'
 
     def validate_record(self):
         """Validate the record in according to the hep schema."""

--- a/inspire_schemas/builders/literature.py
+++ b/inspire_schemas/builders/literature.py
@@ -25,23 +25,23 @@
 """Literature builder class and related code."""
 
 from __future__ import absolute_import, division, print_function
-from six import python_2_unicode_compatible, string_types, text_type
 
 import warnings
 
 import idutils
+from six import python_2_unicode_compatible, string_types, text_type
 
-from inspire_utils.date import normalize_date
-
-from ..utils import (
+from inspire_schemas.builders.builder import RecordBuilder
+from inspire_schemas.builders.signatures import SignatureBuilder
+from inspire_schemas.utils import (
+    EMPTIES,
+    filter_empty_parameters,
     get_license_from_url,
     normalize_collaboration,
     normalize_isbn,
     validate,
-    filter_empty_parameters,
-    EMPTIES
 )
-from .signatures import SignatureBuilder
+from inspire_utils.date import normalize_date
 
 
 def is_citeable(publication_info):
@@ -85,64 +85,19 @@ def key_already_there(element, elements):
 
 
 @python_2_unicode_compatible
-class LiteratureBuilder(object):
+class LiteratureBuilder(RecordBuilder):
     """Literature record builder."""
 
+    _collections = ['Literature']
+
     def __init__(self, source=None, record=None):
-        """Init method.
-
-        :param source: sets the default value for the 'source' fields
-         of the current record, which captures where the information
-         that the builder populates comes from
-        :type source: string
-
-        :param record: sets the default value for the the current
-        record, in order to edit an already existent record
-        :type record: dict
-        """
+        super(LiteratureBuilder, self).__init__(record, source)
         if record is None:
-            self.record = {
-                '_collections': ['Literature'],
-                'curated': False,
-            }
-        else:
-            self.record = record
-
-        self.source = source
-
-    def _append_to(self, field, element):
-        """Append the ``element`` to the ``field`` of the record.
-
-        This method is smart: it does nothing if ``element`` is empty and
-        creates ``field`` if it does not exit yet.
-
-        :param field: the name of the field of the record to append to
-        :type field: string
-        :param element: the element to append
-        """
-        if element not in EMPTIES:
-            self.record.setdefault(field, [])
-            self.record.get(field).append(element)
+            self.record['curated'] = False
 
     def __str__(self):
         """Print the current record."""
         return text_type(self.record)
-
-    def __repr__(self):
-        """Printable representation of the builder."""
-        return u'LiteratureBuilder(source={!r}, record={})'.format(
-            self.source,
-            self.record
-        )
-
-    def _sourced_dict(self, source=None, **kwargs):
-        """Like ``dict(**kwargs)``, but where the ``source`` key is special.
-        """
-        if source:
-            kwargs['source'] = source
-        elif self.source:
-            kwargs['source'] = self.source
-        return kwargs
 
     def validate_record(self):
         """Validate the record in according to the hep schema."""


### PR DESCRIPTION
Code duplication of helper methods such as `_ensure_field` led to subtly diverging implementations across the builders. Let's put a stop to this by making all record builders inherit from a single `RecordBuilder` class containing the implementation of these helper methods.