### PR TITLE
hep schema: update link for CRediT taxonomy

### DIFF
--- a/inspire_schemas/records/hep.yml
+++ b/inspire_schemas/records/hep.yml
@@ -359,7 +359,7 @@ properties:
 
                             Role of the author according to the `Contributor
                             Roles Taxonomy (CRediT)
-                            <http://dictionary.casrai.org/Contributor_Roles>`_
+                            <https://credit.niso.org/>`_
                         enum:
                         - Conceptualization
                         - Data curation


### PR DESCRIPTION
Update the link to `CRediT` taxonomy, because according to the announcement at https://casrai.org/

CASRAI an organisation has ceased to exist, ... 
NISO is taking responsibility for the CRediT taxonomy. For more information, see http://credit.niso.org/

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>