### PR TITLE
signature builder: don't raise

### DIFF
--- a/inspire_schemas/utils.py
+++ b/inspire_schemas/utils.py
@@ -437,14 +437,14 @@ def author_id_normalize_and_schema(uid, schema=None):
 
     if schema and schema not in _RE_AUTHORS_UID:
         # Schema explicitly specified, but this function can't handle it
-        raise UnknownUIDSchema(uid)
+        return uid, schema
 
     if schema:
         normalized_uid = _get_uid_normalized_in_schema(uid, schema)
         if normalized_uid:
             return normalized_uid, schema
         else:
-            raise SchemaUIDConflict(schema, uid)
+            return uid, schema
 
     match_schema, normalized_uid = None, None
     for candidate_schema in _RE_AUTHORS_UID:

--- a/tests/unit/test_signature_builder.py
+++ b/tests/unit/test_signature_builder.py
@@ -27,6 +27,7 @@ import inspect
 
 from inspire_schemas.utils import load_schema, validate
 from inspire_schemas.builders.signatures import SignatureBuilder
+from jsonschema import ValidationError
 
 
 @pytest.fixture(scope='module')
@@ -41,6 +42,12 @@ def assert_field_valid(expected, result, property, schema):
         result[property],
         schema['properties'][property]
     ) is None
+
+
+def assert_field_invalid(expected, result, property, schema):
+    assert expected == result
+    with pytest.raises(ValidationError):
+        assert validate(result[property], schema["properties"][property])
 
 
 def test_ensure_fields():
@@ -207,6 +214,15 @@ def test_set_uid(subschema):
     builder.set_uid('INSPIRE-12345678')
 
     assert_field_valid(expected, builder.obj, 'ids', subschema)
+
+
+def test_set_uid_with_unknown_schema(subschema):
+    expected = {"ids": [{"value": "Frank-Castle", "schema": "a-random-schema"}]}
+
+    builder = SignatureBuilder()
+    builder.set_uid("Frank-Castle", schema="a-random-schema")
+
+    assert_field_invalid(expected, builder.obj, "ids", subschema)
 
 
 def test_add_inspire_role(subschema):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1140,8 +1140,9 @@ def test_author_id_normalize_and_schema_unknown():
 
 
 def test_author_id_normalize_and_schema_conflict():
-    with pytest.raises(errors.SchemaUIDConflict):
-        utils.author_id_normalize_and_schema('SLAC-123456', 'CERN')
+    uid, schema = utils.author_id_normalize_and_schema('SLAC-123456', 'CERN')
+    assert 'SLAC-123456' == uid
+    assert 'CERN' == schema
 
 
 @pytest.mark.parametrize('arg1,arg2,source,material', [


### PR DESCRIPTION
* Don't raise when the schema is unknown.

* Don't raise when schema don't match the value pattern.

* Ref: cern-sis/issues-inspire/issues/60