### PR TITLE
global: update pyyaml version

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install python dependencies
         run: |
           ${{ matrix.pip }} install --user --upgrade pip
-          ${{ matrix.pip }} --no-cache-dir install --user setuptools wheel "urllib3==1.25.11"
+          ${{ matrix.pip }} --no-cache-dir install --user setuptools wheel
           ${{ matrix.pip }} --no-cache-dir install --user -e .[tests,docs]
 
       - name: Show python dependencies
@@ -108,7 +108,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip --no-cache-dir install setuptools wheel "urllib3==1.25.11"
+          pip --no-cache-dir install setuptools wheel
           pip --no-cache-dir install -e .[tests,docs]
 
       - name: Show python dependencies

--- a/scripts/normalize_yaml.py
+++ b/scripts/normalize_yaml.py
@@ -125,7 +125,7 @@ def process_tree(value, key=None, parent_key=None):
 def normalize_yaml(file_name):
     print('Normalizing', file_name, '...')
     with open(file_name, 'r') as file_stream:
-        schema = yaml.load(file_stream)
+        schema = yaml.full_load(file_stream)
 
     schema = process_tree(schema)
     yaml_schema = yaml.dump(schema, **DUMPER_OPTIONS)

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,28 @@ def _generate_json_schemas():
         _yaml2json(yaml_file=yaml_file, json_file=json_file)
 
 
-build_requires = ['pyyaml>=6.0,<7.0']
+build_requires = [
+    'pyyaml>=6.0,<7.0',
+]
+
+install_requires=[
+    'bump2version~=0.0,<1; python_version == "2.7"',
+    'bump2version~=1.0; python_version >= "3"',
+    'bleach~=3.0,>=3.2.1',
+    'Unidecode~=1.0,>=1.0.22',
+    'jsonschema~=2.0,>=2.6.0',
+    'inspire-idutils==1.2.4; python_version == "2.7"',
+    'idutils~=1.2,>=1.2.1; python_version >= "3"',
+    'isbnid',
+    'inspire-utils',
+    'isodate',
+    'pyyaml>=6.0,<7.0',
+    'pytz',
+    'rfc3987',
+    'six',
+    'scrapy',
+    'pylatexenc',
+]
 
 tests_require = [
     'check-manifest',
@@ -205,27 +226,7 @@ def do_setup():
         description='Inspire JSON schemas and utilities to use them.',
         long_description="Inspire JSON schemas and utilities to use them.",
         long_description_content_type='text/plain',
-        install_requires=[
-            'bump2version~=0.0,<1; python_version == "2.7"',
-            'bump2version~=1.0; python_version >= "3"',
-            'bleach~=3.0,>=3.2.1',
-            'Unidecode~=1.0,>=1.0.22',
-            'jsonschema~=2.0,>=2.6.0',
-            'inspire-idutils==1.2.4; python_version == "2.7"',
-            'idutils~=1.2,>=1.2.1; python_version >= "3"',
-            'isbnid',
-            'inspire-utils~=3.0,>=3.0.0',
-            'isodate',
-            'pyyaml>=6.0,<7.0',
-            'pytz',
-            'rfc3987',
-            'six',
-            # requests requires a urllib3 version <1.26 but not 1.25.0 and 1.25.1
-            # we pin it down here to solve dependency problems
-            'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
-            'scrapy',
-            'pylatexenc',
-        ],
+        install_requires=install_requires,
         tests_require=tests_require,
         extras_require=extras_require,
         build_requires=build_requires,
@@ -233,7 +234,7 @@ def do_setup():
         name='inspire-schemas',
         package_data={'': ['*.json', 'CHANGELOG', 'AUTHORS']},
         packages=find_packages(),
-        setup_requires=['pyyaml>=6.0,<7.0'],
+        setup_requires=install_requires,
         url=URL,
         bugtracker_url=URL + '/issues/',
         zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def _resolve_json_schema(json_schema, path):
                 subschema_path = os.path.splitext(subschema_path)[0]
                 with open(subschema_path + '.yml', 'rb') as yaml_fd:
                     raw_data = yaml_fd.read()
-                data = yaml.load(raw_data)
+                data = yaml.full_load(raw_data)
                 data = _resolve_json_schema(
                     data, os.path.join(path, os.path.dirname(json_schema[key]))
                 )
@@ -86,7 +86,7 @@ def _yaml2json(yaml_file, json_file):
 
     with open(yaml_file, 'rb') as yaml_fd:
         raw_data = yaml_fd.read()
-    data = yaml.load(raw_data)
+    data = yaml.full_load(raw_data)
     with open(json_file, 'w') as json_fd:
         json.dump(data, json_fd, indent=4, separators=(',', ': '), sort_keys=True)
         json_fd.write('\n')
@@ -156,7 +156,7 @@ def _generate_json_schemas():
         _yaml2json(yaml_file=yaml_file, json_file=json_file)
 
 
-build_requires = ['pyyaml>=5.3.0']
+build_requires = ['pyyaml>=6.0,<7.0']
 
 tests_require = [
     'check-manifest',
@@ -174,7 +174,7 @@ tests_require = [
 ]
 
 docs_require = [
-    'jsonschema2rst>=0.1',
+    'jsonschema2rst>=0.1.6',
     'Sphinx',
 ]
 
@@ -216,7 +216,7 @@ def do_setup():
             'isbnid',
             'inspire-utils~=3.0,>=3.0.0',
             'isodate',
-            'pyyaml==5.3.0',
+            'pyyaml>=6.0,<7.0',
             'pytz',
             'rfc3987',
             'six',
@@ -233,7 +233,7 @@ def do_setup():
         name='inspire-schemas',
         package_data={'': ['*.json', 'CHANGELOG', 'AUTHORS']},
         packages=find_packages(),
-        setup_requires=['pyyaml==5.3.0'],
+        setup_requires=['pyyaml>=6.0,<7.0'],
         url=URL,
         bugtracker_url=URL + '/issues/',
         zip_safe=False,

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -37,7 +37,7 @@ FIXTURES_PATH = os.path.join(os.path.dirname(__file__), 'fixtures')
 def load_file(file_name):
     path = os.path.join(FIXTURES_PATH, file_name)
     with open(path) as input_data:
-        data = yaml.load(input_data.read())
+        data = yaml.full_load(input_data.read())
 
     return data
 

--- a/tests/unit/test_parsers_crossref.py
+++ b/tests/unit/test_parsers_crossref.py
@@ -40,7 +40,7 @@ def get_parsed_from_file(filename):
     """A dictionary holding the parsed elements of the record."""
     path = get_test_suite_path('crossref', filename)
     with open(path) as f:
-        aps_dict = yaml.load(f)
+        aps_dict = yaml.full_load(f)
 
     return aps_dict
 

--- a/tests/unit/test_parsers_elsevier.py
+++ b/tests/unit/test_parsers_elsevier.py
@@ -41,7 +41,7 @@ def get_parsed_from_file(filename):
     """A dictionary holding the parsed elements of the record."""
     path = get_test_suite_path('elsevier', filename)
     with open(path) as f:
-        elsevier_expected_dict = yaml.load(f)
+        elsevier_expected_dict = yaml.full_load(f)
 
     return elsevier_expected_dict
 

--- a/tests/unit/test_parsers_jats.py
+++ b/tests/unit/test_parsers_jats.py
@@ -41,7 +41,7 @@ def get_parsed_from_file(filename):
     """A dictionary holding the parsed elements of the record."""
     path = get_test_suite_path('aps', filename)
     with open(path) as f:
-        aps_expected_dict = yaml.load(f)
+        aps_expected_dict = yaml.full_load(f)
 
     return aps_expected_dict
 


### PR DESCRIPTION
bump pyyaml to 6.x in order to be able to use inspire-schemas for: https://github.com/cern-sis/issues-inspire/issues/574
Remove urlib3 dependency