### PR TITLE
feat[DataBuilder]: Pass doi value directly when adding literature

### DIFF
--- a/inspire_schemas/builders/data.py
+++ b/inspire_schemas/builders/data.py
@@ -297,20 +297,26 @@ class DataBuilder(RecordBuilder):
         self._append_to('urls', entry)
 
     @filter_empty_parameters
-    def add_literature(self, doi=None, record=None):
+    def add_literature(self, doi=None, record=None, source=None):
         """Add literature.
 
         :param doi: doi of the literature
-        :type doi: dict
+        :type doi: str
 
         :param record: dictionary with ``$ref`` pointing to proper record.
         :type record: dict
+
+        :param source: source of the doi
+        :type source: str
         """
         literature_dict = {
             'record': record,
         }
 
         if doi:
-            literature_dict['doi'] = doi
+            if source:
+                literature_dict['doi'] = self._sourced_dict(source, value=doi)
+            else:
+                literature_dict['doi'] = {"value": doi}
 
         self._append_to('literature', literature_dict)

--- a/tests/integration/test_builders.py
+++ b/tests/integration/test_builders.py
@@ -485,7 +485,7 @@ def test_data_builder(data_data):
 
     literatures = data_data['literature']
     for literature in literatures:
-        builder.add_literature(literature.get("doi"), literature.get('record'))
+        builder.add_literature(literature.get("doi", {}).get("value"), literature.get('record'), literature.get("doi", {}).get("source"))
     assert builder.record['literature'] == literatures
 
     urls = data_data['urls']

--- a/tests/unit/test_data_builder.py
+++ b/tests/unit/test_data_builder.py
@@ -42,6 +42,7 @@ def test_add_abstract():
     abstract = "This is a test abstract."
     source = "Test Source"
     builder.add_abstract(abstract, source)
+    builder.validate_record()
     result = builder.record.get("abstracts")
     expected = [{"source": source, "value": abstract}]
     assert result == expected
@@ -55,6 +56,7 @@ def test_add_author():
         "emails": ["john.smith@example.org"],
     }
     builder.add_author(author_data)
+    builder.validate_record()
     result = builder.record.get("authors")
     expected = [author_data]
     assert result == expected
@@ -66,6 +68,7 @@ def test_add_title():
     subtitle = "An Even Better Subtitle"
     source = "Test Source"
     builder.add_title(title, subtitle, source)
+    builder.validate_record()
     result = builder.record.get("titles")
     expected = [
         {"source": source, "title": title, "subtitle": subtitle},
@@ -76,6 +79,7 @@ def test_add_creation_date():
     builder = DataBuilder()
     creation_date = "2020-01-01"
     builder.add_creation_date(creation_date)
+    builder.validate_record()
     result = builder.record.get("creation_date")
     assert result == creation_date
 
@@ -84,6 +88,7 @@ def test_add_doi():
     doi = "10.1234/example.doi"
     source = "Test Source"
     builder.add_doi(doi, source)
+    builder.validate_record()
     result = builder.record.get("dois")
     expected = [{"source": source, "value": "10.1234/example.doi"}]
     assert result == expected
@@ -94,6 +99,7 @@ def test_add_keyword():
     keyword = "Physics"
     source = "Test Source"
     builder.add_keyword(keyword, source)
+    builder.validate_record()
     result = builder.record.get("keywords")
     expected = [{"source": source, "value": keyword}]
     assert result == expected
@@ -104,6 +110,7 @@ def test_add_accelerator_experiment():
     legacy_name = "FNAL-E-0900"
     experiment_record = {"$ref": "http://example.com/api/experiments/123"}
     builder.add_accelerator_experiment(legacy_name, record=experiment_record)
+    builder.validate_record()
     result = builder.record.get("accelerator_experiments")
     expected = [{"legacy_name": legacy_name, "record": experiment_record}]
     assert result == expected
@@ -114,14 +121,21 @@ def test_add_literature():
 
     doi = "10.1234/example.doi"
     record = {"$ref": "http://example.com/api/literature/123"}
+    source = "testsource"
 
-    builder.add_literature(doi, record=record)
+    builder.add_literature(doi, record=record, source=source)
+    builder.validate_record()
 
     result = builder.record.get("literature")
     expected = [
         {
-            "doi": doi,
-            "record": record,
+            "doi":{
+                "source": "testsource",
+                "value":"10.1234/example.doi"
+            },
+            "record":{
+                "$ref":"http://example.com/api/literature/123"
+            }
         }
     ]
 


### PR DESCRIPTION
- Also Added record validation in unit tests in order to avoid testing wrong behavior, as was previously happening with test_add_literature.

ref: https://github.com/cern-sis/issues-inspire/issues/631